### PR TITLE
feat: Implement Cargo Manifest and Draft MAWB APIs

### DIFF
--- a/factory/repository.go
+++ b/factory/repository.go
@@ -33,6 +33,8 @@ type RepositoryFactory struct {
 	ShopeeRepo                    shopee.Repository
 	MawbRepo                      mawb.Repository
 	MawbInfoRepo                  mawbinfo.Repository
+	CargoManifestRepo             mawbinfo.CargoManifestRepository
+	DraftMAWBRepo                 mawbinfo.DraftMAWBRepository
 	CustomerRepo                  customer.Repository
 	DashboardRepo                 dashboard.Repository
 	UserRepo                      user.Repository
@@ -54,6 +56,8 @@ func NewRepositoryFactory() *RepositoryFactory {
 		ShopeeRepo:                    shopee.NewRepository(timeoutContext),
 		MawbRepo:                      mawb.NewRepository(timeoutContext),
 		MawbInfoRepo:                  mawbinfo.NewRepository(timeoutContext),
+		CargoManifestRepo:             mawbinfo.NewCargoManifestRepository(timeoutContext),
+		DraftMAWBRepo:                 mawbinfo.NewDraftMAWBRepository(timeoutContext),
 		CustomerRepo:                  customer.NewRepository(timeoutContext),
 		DashboardRepo:                 dashboard.NewRepository(timeoutContext),
 		UserRepo:                      user.NewRepository(timeoutContext),

--- a/factory/service.go
+++ b/factory/service.go
@@ -36,6 +36,8 @@ type ServiceFactory struct {
 	ShopeeSvc                 shopee.Service
 	MawbSvc                   mawb.Service
 	MawbInfoSvc               mawbinfo.Service
+	CargoManifestSvc          mawbinfo.CargoManifestService
+	DraftMAWBSvc              mawbinfo.DraftMAWBService
 	CustomerSvc               customer.Service
 	DashboardSvc              dashboard.Service
 	UserSvc                   user.Service
@@ -95,6 +97,20 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 	// MawbInfo
 	mawbInfoSvc := mawbinfo.NewService(
 		repo.MawbInfoRepo,
+		timeoutContext,
+	)
+
+	// CargoManifest
+	cargoManifestSvc := mawbinfo.NewCargoManifestService(
+		repo.MawbInfoRepo,
+		repo.CargoManifestRepo,
+		timeoutContext,
+	)
+
+	// DraftMAWB
+	draftMAWBSvc := mawbinfo.NewDraftMAWBService(
+		repo.MawbInfoRepo,
+		repo.DraftMAWBRepo,
 		timeoutContext,
 	)
 	/*
@@ -163,6 +179,8 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 		ShopeeSvc:                 shopeeSvc,
 		MawbSvc:                   mawbSvc,
 		MawbInfoSvc:               mawbInfoSvc,
+		CargoManifestSvc:          cargoManifestSvc,
+		DraftMAWBSvc:              draftMAWBSvc,
 		CustomerSvc:               customerSvc,
 		DashboardSvc:              dashboardSvc,
 		UserSvc:                   userSvc,

--- a/outbound/mawbinfo/cargo_manifest.go
+++ b/outbound/mawbinfo/cargo_manifest.go
@@ -1,0 +1,47 @@
+package mawbinfo
+
+import (
+	"net/http"
+	"time"
+)
+
+type CargoManifest struct {
+	UUID            string              `json:"uuid" db:"uuid"`
+	MAWBInfoUUID    string              `json:"mawb_info_uuid" db:"mawb_info_uuid"`
+	MAWBNumber      string              `json:"mawbNumber" db:"mawb_number" validate:"required"`
+	PortOfDischarge string              `json:"portOfDischarge" db:"port_of_discharge"`
+	FlightNo        string              `json:"flightNo" db:"flight_no"`
+	FreightDate     string              `json:"freightDate" db:"freight_date"`
+	Shipper         string              `json:"shipper" db:"shipper"`
+	Consignee       string              `json:"consignee" db:"consignee"`
+	TotalCtn        string              `json:"totalCtn" db:"total_ctn"`
+	Transshipment   string              `json:"transshipment" db:"transshipment"`
+	Status          string              `json:"status" db:"status"`
+	Items           []CargoManifestItem `json:"items" validate:"required,dive"`
+	CreatedAt       time.Time           `json:"createdAt" db:"created_at"`
+	UpdatedAt       time.Time           `json:"updatedAt" db:"updated_at"`
+}
+
+type CargoManifestItem struct {
+	ID                      int    `json:"id,omitempty" db:"id"`
+	CargoManifestUUID       string `json:"cargo_manifest_uuid,omitempty" db:"cargo_manifest_uuid"`
+	HAWBNo                  string `json:"hawbNo" db:"hawb_no"`
+	Pkgs                    string `json:"pkgs" db:"pkgs"`
+	GrossWeight             string `json:"grossWeight" db:"gross_weight"`
+	Destination             string `json:"dst" db:"destination"`
+	Commodity               string `json:"commodity" db:"commodity"`
+	ShipperNameAndAddress   string `json:"shipperNameAndAddress" db:"shipper_name_address"`
+	ConsigneeNameAndAddress string `json:"consigneeNameAndAddress" db:"consignee_name_address"`
+}
+
+// Bind for CargoManifest - for request body binding
+func (cm *CargoManifest) Bind(r *http.Request) error {
+	// a good place to do validation or transformation on the request body
+	return nil
+}
+
+// Render for CargoManifest - for response rendering
+func (cm *CargoManifest) Render(w http.ResponseWriter, r *http.Request) error {
+	// a good place to do pre-processing before sending response
+	return nil
+}

--- a/outbound/mawbinfo/cargo_manifest_repository.go
+++ b/outbound/mawbinfo/cargo_manifest_repository.go
@@ -1,0 +1,197 @@
+package mawbinfo
+
+import (
+	"context"
+	"database/sql"
+	"hpc-express-service/utils"
+	"time"
+
+	"github.com/go-pg/pg/v9"
+	"github.com/go-pg/pg/v9/orm"
+)
+
+type CargoManifestRepository interface {
+	GetByMAWBInfoUUID(ctx context.Context, mawbInfoUUID string) (*CargoManifest, error)
+	CreateOrUpdate(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
+	UpdateStatus(ctx context.Context, mawbInfoUUID, status string) error
+}
+
+type cargoManifestRepository struct {
+	contextTimeout time.Duration
+}
+
+func NewCargoManifestRepository(timeout time.Duration) CargoManifestRepository {
+	return &cargoManifestRepository{
+		contextTimeout: timeout,
+	}
+}
+
+func (r *cargoManifestRepository) GetByMAWBInfoUUID(ctx context.Context, mawbInfoUUID string) (*CargoManifest, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(ctx, r.contextTimeout)
+	defer cancel()
+
+	if err := r.createTablesIfNotExists(ctx, db); err != nil {
+		return nil, err
+	}
+
+	var manifest CargoManifest
+	err := db.Model(&manifest).
+		Where("mawb_info_uuid = ?", mawbInfoUUID).
+		Select()
+
+	if err != nil {
+		if err == pg.ErrNoRows {
+			return nil, nil // Not found is not an error here
+		}
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	// Now, load the items for the manifest
+	err = db.Model(&manifest.Items).
+		Where("cargo_manifest_uuid = ?", manifest.UUID).
+		Select()
+
+	if err != nil && err != pg.ErrNoRows {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	return &manifest, nil
+}
+
+func (r *cargoManifestRepository) CreateOrUpdate(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(ctx, r.contextTimeout)
+	defer cancel()
+
+	if err := r.createTablesIfNotExists(ctx, db); err != nil {
+		return nil, err
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+	defer tx.Rollback()
+
+	// Check if a manifest already exists for this mawb_info_uuid
+	existingManifest := &CargoManifest{}
+	err = tx.Model(existingManifest).Where("mawb_info_uuid = ?", manifest.MAWBInfoUUID).Select()
+
+	if err != nil && err != pg.ErrNoRows {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	if existingManifest.UUID != "" { // Update existing
+		manifest.UUID = existingManifest.UUID
+		manifest.CreatedAt = existingManifest.CreatedAt
+		_, err = tx.Model(manifest).WherePK().Update()
+		if err != nil {
+			return nil, utils.PostgresErrorTransform(err)
+		}
+
+		// Delete old items
+		_, err = tx.Model(&CargoManifestItem{}).Where("cargo_manifest_uuid = ?", manifest.UUID).Delete()
+		if err != nil {
+			return nil, utils.PostgresErrorTransform(err)
+		}
+	} else { // Insert new
+		_, err = tx.Model(manifest).Insert()
+		if err != nil {
+			return nil, utils.PostgresErrorTransform(err)
+		}
+	}
+
+	// Insert new items
+	for i := range manifest.Items {
+		manifest.Items[i].CargoManifestUUID = manifest.UUID
+	}
+
+	if len(manifest.Items) > 0 {
+		_, err = tx.Model(&manifest.Items).Insert()
+		if err != nil {
+			return nil, utils.PostgresErrorTransform(err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	// Refetch to get all default values and timestamps
+	return r.GetByMAWBInfoUUID(ctx, manifest.MAWBInfoUUID)
+}
+
+func (r *cargoManifestRepository) UpdateStatus(ctx context.Context, mawbInfoUUID, status string) error {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(ctx, r.contextTimeout)
+	defer cancel()
+
+	if err := r.createTablesIfNotExists(ctx, db); err != nil {
+		return err
+	}
+
+	res, err := db.Model(&CargoManifest{}).
+		Set("status = ?, updated_at = ?", status, time.Now()).
+		Where("mawb_info_uuid = ?", mawbInfoUUID).
+		Update()
+
+	if err != nil {
+		return utils.PostgresErrorTransform(err)
+	}
+	if res.RowsAffected() == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}
+
+func (r *cargoManifestRepository) createTablesIfNotExists(ctx context.Context, db orm.DB) error {
+	queries := []string{
+		`CREATE TABLE IF NOT EXISTS cargo_manifest (
+			uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			mawb_info_uuid UUID NOT NULL,
+			mawb_number VARCHAR(255) NOT NULL,
+			port_of_discharge VARCHAR(255),
+			flight_no VARCHAR(100),
+			freight_date VARCHAR(50),
+			shipper TEXT,
+			consignee TEXT,
+			total_ctn VARCHAR(100),
+			transshipment TEXT,
+			status VARCHAR(50) DEFAULT 'Draft',
+			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			CONSTRAINT fk_mawb_info
+				FOREIGN KEY(mawb_info_uuid)
+				REFERENCES tbl_mawb_info(uuid)
+				ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_cargo_manifest_mawb_info_uuid ON cargo_manifest(mawb_info_uuid)`,
+		`CREATE TABLE IF NOT EXISTS cargo_manifest_items (
+			id SERIAL PRIMARY KEY,
+			cargo_manifest_uuid UUID NOT NULL,
+			hawb_no VARCHAR(255),
+			pkgs VARCHAR(100),
+			gross_weight VARCHAR(100),
+			destination VARCHAR(100),
+			commodity TEXT,
+			shipper_name_address TEXT,
+			consignee_name_address TEXT,
+			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			CONSTRAINT fk_cargo_manifest
+				FOREIGN KEY(cargo_manifest_uuid)
+				REFERENCES cargo_manifest(uuid)
+				ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_cargo_manifest_items_uuid ON cargo_manifest_items(cargo_manifest_uuid)`,
+	}
+
+	for _, query := range queries {
+		_, err := db.Exec(query)
+		if err != nil {
+			return utils.PostgresErrorTransform(err)
+		}
+	}
+	return nil
+}

--- a/outbound/mawbinfo/cargo_manifest_service.go
+++ b/outbound/mawbinfo/cargo_manifest_service.go
@@ -1,0 +1,125 @@
+package mawbinfo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/go-playground/validator"
+)
+
+type CargoManifestService interface {
+	GetCargoManifest(ctx context.Context, mawbInfoUUID string) (*CargoManifest, error)
+	CreateOrUpdateCargoManifest(ctx context.Context, mawbInfoUUID string, req *CargoManifest) (*CargoManifest, error)
+	UpdateCargoManifestStatus(ctx context.Context, mawbInfoUUID, status string) error
+}
+
+type cargoManifestService struct {
+	mawbInfoRepo      Repository
+	cargoManifestRepo CargoManifestRepository
+	contextTimeout    time.Duration
+	validate          *validator.Validate
+}
+
+func NewCargoManifestService(
+	mawbInfoRepo Repository,
+	cargoManifestRepo CargoManifestRepository,
+	timeout time.Duration,
+) CargoManifestService {
+	return &cargoManifestService{
+		mawbInfoRepo:      mawbInfoRepo,
+		cargoManifestRepo: cargoManifestRepo,
+		contextTimeout:    timeout,
+		validate:          validator.New(),
+	}
+}
+
+func (s *cargoManifestService) GetCargoManifest(ctx context.Context, mawbInfoUUID string) (*CargoManifest, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(mawbInfoUUID) == "" {
+		return nil, errors.New("mawb info uuid is required")
+	}
+
+	manifest, err := s.cargoManifestRepo.GetByMAWBInfoUUID(ctx, mawbInfoUUID)
+	if err != nil {
+		return nil, err
+	}
+	if manifest == nil {
+		return nil, sql.ErrNoRows // Use standard error for not found
+	}
+
+	return manifest, nil
+}
+
+func (s *cargoManifestService) CreateOrUpdateCargoManifest(ctx context.Context, mawbInfoUUID string, req *CargoManifest) (*CargoManifest, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(mawbInfoUUID) == "" {
+		return nil, errors.New("mawb info uuid is required")
+	}
+
+	// 1. Validate that the MAWB Info record exists
+	_, err := s.mawbInfoRepo.GetMawbInfo(ctx, mawbInfoUUID)
+	if err != nil {
+		if err == sql.ErrNoRows || strings.Contains(err.Error(), "no rows") {
+			return nil, errors.New("mawb info not found")
+		}
+		return nil, err
+	}
+
+	// 2. Validate the request body
+	if err := s.validate.Struct(req); err != nil {
+		return nil, err
+	}
+
+	// 3. Set the UUID from the path and pass to repository
+	req.MAWBInfoUUID = mawbInfoUUID
+	req.Status = "Draft" // Always starts as Draft
+
+	result, err := s.cargoManifestRepo.CreateOrUpdate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *cargoManifestService) UpdateCargoManifestStatus(ctx context.Context, mawbInfoUUID, status string) error {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(mawbInfoUUID) == "" {
+		return errors.New("mawb info uuid is required")
+	}
+
+	// Validate status
+	validStatuses := map[string]bool{"Confirmed": true, "Rejected": true}
+	if !validStatuses[status] {
+		return errors.New("invalid status provided")
+	}
+
+	// 1. Validate that the MAWB Info record exists
+	_, err := s.mawbInfoRepo.GetMawbInfo(ctx, mawbInfoUUID)
+	if err != nil {
+		if err == sql.ErrNoRows || strings.Contains(err.Error(), "no rows") {
+			return errors.New("mawb info not found")
+		}
+		return err
+	}
+
+	// 2. Call repository to update status
+	err = s.cargoManifestRepo.UpdateStatus(ctx, mawbInfoUUID, status)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return errors.New("cargo manifest not found for this mawb")
+		}
+		return err
+	}
+
+	return nil
+}

--- a/outbound/mawbinfo/draft_mawb.go
+++ b/outbound/mawbinfo/draft_mawb.go
@@ -1,0 +1,105 @@
+package mawbinfo
+
+import (
+	"net/http"
+	"time"
+)
+
+type DraftMAWB struct {
+	UUID                        string            `json:"uuid" db:"uuid"`
+	MAWBInfoUUID                string            `json:"mawb_info_uuid" db:"mawb_info_uuid"`
+	CustomerUUID                string            `json:"customerUUID" db:"customer_uuid"`
+	AirlineLogo                 string            `json:"airlineLogo" db:"airline_logo"`
+	AirlineName                 string            `json:"airlineName" db:"airline_name"`
+	MAWB                        string            `json:"mawb" db:"mawb"`
+	HAWB                        string            `json:"hawb" db:"hawb"`
+	ShipperNameAndAddress       string            `json:"shipperNameAndAddress" db:"shipper_name_and_address"`
+	AWBIssuedBy                 string            `json:"awbIssuedBy" db:"awb_issued_by"`
+	ConsigneeNameAndAddress     string            `json:"consigneeNameAndAddress" db:"consignee_name_and_address"`
+	IssuingCarrierAgentName     string            `json:"issuingCarrierAgentName" db:"issuing_carrier_agent_name"`
+	AccountingInfomation        string            `json:"accountingInfomation" db:"accounting_infomation"`
+	AgentsIATACode              string            `json:"agentsIATACode" db:"agents_iata_code"`
+	AccountNo                   string            `json:"accountNo" db:"account_no"`
+	AirportOfDeparture          string            `json:"airportOfDeparture" db:"airport_of_departure"`
+	ReferenceNumber             string            `json:"referenceNumber" db:"reference_number"`
+	OptionalShippingInfo1       string            `json:"optionalShippingInfo1" db:"optional_shipping_info1"`
+	OptionalShippingInfo2       string            `json:"optionalShippingInfo2" db:"optional_shipping_info2"`
+	RoutingTo                   string            `json:"routingTo" db:"routing_to"`
+	RoutingBy                   string            `json:"routingBy" db:"routing_by"`
+	DestinationTo1              string            `json:"destinationTo1" db:"destination_to1"`
+	DestinationBy1              string            `json:"destinationBy1" db:"destination_by1"`
+	DestinationTo2              string            `json:"destinationTo2" db:"destination_to2"`
+	DestinationBy2              string            `json:"destinationBy2" db:"destination_by2"`
+	Currency                    string            `json:"currency" db:"currency"`
+	ChgsCode                    string            `json:"chgsCode" db:"chgs_code"`
+	WtValPpd                    string            `json:"wtValPpd" db:"wt_val_ppd"`
+	WtValColl                   string            `json:"wtValColl" db:"wt_val_coll"`
+	OtherPpd                    string            `json:"otherPpd" db:"other_ppd"`
+	OtherColl                   string            `json:"otherColl" db:"other_coll"`
+	DeclaredValCarriage         string            `json:"declaredValCarriage" db:"declared_val_carriage"`
+	DeclaredValCustoms          string            `json:"declaredValCustoms" db:"declared_val_customs"`
+	AirportOfDestination        string            `json:"airportOfDestination" db:"airport_of_destination"`
+	RequestedFlightDate1        string            `json:"requestedFlightDate1" db:"requested_flight_date1"`
+	RequestedFlightDate2        string            `json:"requestedFlightDate2" db:"requested_flight_date2"`
+	AmountOfInsurance           string            `json:"amountOfInsurance" db:"amount_of_insurance"`
+	HandlingInfomation          string            `json:"handlingInfomation" db:"handling_infomation"`
+	SCI                         string            `json:"sci" db:"sci"`
+	Prepaid                     float64           `json:"prepaid" db:"prepaid"`
+	ValuationCharge             float64           `json:"valuationCharge" db:"valuation_charge"`
+	Tax                         float64           `json:"tax" db:"tax"`
+	TotalOtherChargesDueAgent   float64           `json:"totalOtherChargesDueAgent" db:"total_other_charges_due_agent"`
+	TotalOtherChargesDueCarrier float64           `json:"totalOtherChargesDueCarrier" db:"total_other_charges_due_carrier"`
+	TotalPrepaid                float64           `json:"totalPrepaid" db:"total_prepaid"`
+	CurrencyConversionRates     string            `json:"currencyConversionRates" db:"currency_conversion_rates"`
+	Signature1                  string            `json:"signature1" db:"signature1"`
+	Signature2Date              *time.Time        `json:"signature2Date" db:"signature2_date"`
+	Signature2Place             string            `json:"signature2Place" db:"signature2_place"`
+	Signature2Issuing           string            `json:"signature2Issuing" db:"signature2_issuing"`
+	ShippingMark                string            `json:"shippingMark" db:"shipping_mark"`
+	Status                      string            `json:"status" db:"status"`
+	Items                       []DraftMAWBItem   `json:"items" validate:"required,dive"`
+	Charges                     []DraftMAWBCharge `json:"charges" validate:"dive"`
+	CreatedAt                   time.Time         `json:"createdAt" db:"created_at"`
+	UpdatedAt                   time.Time         `json:"updatedAt" db:"updated_at"`
+}
+
+type DraftMAWBItem struct {
+	ID                int                `json:"id" db:"id"`
+	DraftMAWBUUID     string             `json:"draft_mawb_uuid,omitempty" db:"draft_mawb_uuid"`
+	PiecesRCP         string             `json:"piecesRCP" db:"pieces_rcp"`
+	GrossWeight       string             `json:"grossWeight" db:"gross_weight"`
+	KgLb              string             `json:"kgLb" db:"kg_lb"`
+	RateClass         string             `json:"rateClass" db:"rate_class"`
+	TotalVolume       string             `json:"totalVolume" db:"total_volume"`
+	ChargeableWeight  string             `json:"chargeableWeight" db:"chargeable_weight"`
+	RateCharge        float64            `json:"rateCharge" db:"rate_charge"`
+	Total             float64            `json:"total" db:"total"`
+	NatureAndQuantity string             `json:"natureAndQuantity" db:"nature_and_quantity"`
+	Dims              []DraftMAWBItemDim `json:"dims" validate:"required,dive"`
+}
+
+type DraftMAWBItemDim struct {
+	ID              int    `json:"id,omitempty" db:"id"`
+	DraftMAWBItemID int    `json:"draft_mawb_item_id,omitempty" db:"draft_mawb_item_id"`
+	Length          string `json:"length" db:"length"`
+	Width           string `json:"width" db:"width"`
+	Height          string `json:"height" db:"height"`
+	Count           string `json:"count" db:"count"`
+}
+
+type DraftMAWBCharge struct {
+	ID            int     `json:"id,omitempty" db:"id"`
+	DraftMAWBUUID string  `json:"draft_mawb_uuid,omitempty" db:"draft_mawb_uuid"`
+	Key           string  `json:"key" db:"charge_key"`
+	Value         float64 `json:"value" db:"charge_value"`
+}
+
+// Bind for DraftMAWB
+func (dm *DraftMAWB) Bind(r *http.Request) error {
+	return nil
+}
+
+// Render for DraftMAWB
+func (dm *DraftMAWB) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}

--- a/outbound/mawbinfo/draft_mawb_repository.go
+++ b/outbound/mawbinfo/draft_mawb_repository.go
@@ -1,0 +1,325 @@
+package mawbinfo
+
+import (
+	"context"
+	"database/sql"
+	"hpc-express-service/utils"
+	"time"
+
+	"github.com/go-pg/pg/v9"
+	"github.com/go-pg/pg/v9/orm"
+)
+
+type DraftMAWBRepository interface {
+	GetByMAWBInfoUUID(ctx context.Context, mawbInfoUUID string) (*DraftMAWB, error)
+	CreateOrUpdate(ctx context.Context, draft *DraftMAWB) (*DraftMAWB, error)
+	UpdateStatus(ctx context.Context, mawbInfoUUID, status string) error
+}
+
+type draftMAWBRepository struct {
+	contextTimeout time.Duration
+}
+
+func NewDraftMAWBRepository(timeout time.Duration) DraftMAWBRepository {
+	return &draftMAWBRepository{
+		contextTimeout: timeout,
+	}
+}
+
+func (r *draftMAWBRepository) GetByMAWBInfoUUID(ctx context.Context, mawbInfoUUID string) (*DraftMAWB, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(ctx, r.contextTimeout)
+	defer cancel()
+
+	if err := r.createTablesIfNotExists(ctx, db); err != nil {
+		return nil, err
+	}
+
+	var draft DraftMAWB
+	err := db.Model(&draft).
+		Where("mawb_info_uuid = ?", mawbInfoUUID).
+		Select()
+
+	if err != nil {
+		if err == pg.ErrNoRows {
+			return nil, nil // Not found
+		}
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	// Load related entities
+	if err := r.loadRelated(db, &draft); err != nil {
+		return nil, err
+	}
+
+	return &draft, nil
+}
+
+func (r *draftMAWBRepository) CreateOrUpdate(ctx context.Context, draft *DraftMAWB) (*DraftMAWB, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(ctx, r.contextTimeout)
+	defer cancel()
+
+	if err := r.createTablesIfNotExists(ctx, db); err != nil {
+		return nil, err
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+	defer tx.Rollback()
+
+	// Upsert logic for the main draft_mawb table
+	existingDraft := &DraftMAWB{}
+	err = tx.Model(existingDraft).Where("mawb_info_uuid = ?", draft.MAWBInfoUUID).Select()
+	if err != nil && err != pg.ErrNoRows {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	if existingDraft.UUID != "" { // Update
+		draft.UUID = existingDraft.UUID
+		draft.CreatedAt = existingDraft.CreatedAt
+		_, err = tx.Model(draft).WherePK().Update()
+		if err != nil {
+			return nil, utils.PostgresErrorTransform(err)
+		}
+		// Delete old children
+		if err := r.deleteChildren(tx, draft.UUID); err != nil {
+			return nil, err
+		}
+	} else { // Insert
+		_, err = tx.Model(draft).Insert()
+		if err != nil {
+			return nil, utils.PostgresErrorTransform(err)
+		}
+	}
+
+	// Insert new children
+	for i := range draft.Items {
+		draft.Items[i].DraftMAWBUUID = draft.UUID
+		_, err := tx.Model(&draft.Items[i]).Insert()
+		if err != nil {
+			return nil, utils.PostgresErrorTransform(err)
+		}
+		for j := range draft.Items[i].Dims {
+			draft.Items[i].Dims[j].DraftMAWBItemID = draft.Items[i].ID
+		}
+		if len(draft.Items[i].Dims) > 0 {
+			_, err = tx.Model(&draft.Items[i].Dims).Insert()
+			if err != nil {
+				return nil, utils.PostgresErrorTransform(err)
+			}
+		}
+	}
+
+	for i := range draft.Charges {
+		draft.Charges[i].DraftMAWBUUID = draft.UUID
+	}
+	if len(draft.Charges) > 0 {
+		_, err = tx.Model(&draft.Charges).Insert()
+		if err != nil {
+			return nil, utils.PostgresErrorTransform(err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	return r.GetByMAWBInfoUUID(ctx, draft.MAWBInfoUUID)
+}
+
+func (r *draftMAWBRepository) UpdateStatus(ctx context.Context, mawbInfoUUID, status string) error {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(ctx, r.contextTimeout)
+	defer cancel()
+
+	if err := r.createTablesIfNotExists(ctx, db); err != nil {
+		return err
+	}
+
+	res, err := db.Model(&DraftMAWB{}).
+		Set("status = ?, updated_at = ?", status, time.Now()).
+		Where("mawb_info_uuid = ?", mawbInfoUUID).
+		Update()
+
+	if err != nil {
+		return utils.PostgresErrorTransform(err)
+	}
+	if res.RowsAffected() == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}
+
+func (r *draftMAWBRepository) loadRelated(db orm.DB, draft *DraftMAWB) error {
+	// Load items
+	if err := db.Model(&draft.Items).Where("draft_mawb_uuid = ?", draft.UUID).Select(); err != nil && err != pg.ErrNoRows {
+		return utils.PostgresErrorTransform(err)
+	}
+
+	// For each item, load its dimensions
+	for i := range draft.Items {
+		if err := db.Model(&draft.Items[i].Dims).Where("draft_mawb_item_id = ?", draft.Items[i].ID).Select(); err != nil && err != pg.ErrNoRows {
+			return utils.PostgresErrorTransform(err)
+		}
+	}
+
+	// Load charges
+	if err := db.Model(&draft.Charges).Where("draft_mawb_uuid = ?", draft.UUID).Select(); err != nil && err != pg.ErrNoRows {
+		return utils.PostgresErrorTransform(err)
+	}
+
+	return nil
+}
+
+func (r *draftMAWBRepository) deleteChildren(tx *pg.Tx, draftUUID string) error {
+	// Need to get item IDs to delete dims first
+	var items []DraftMAWBItem
+	err := tx.Model(&items).Column("id").Where("draft_mawb_uuid = ?", draftUUID).Select()
+	if err != nil && err != pg.ErrNoRows {
+		return utils.PostgresErrorTransform(err)
+	}
+
+	if len(items) > 0 {
+		var itemIDs []int
+		for _, item := range items {
+			itemIDs = append(itemIDs, item.ID)
+		}
+		_, err = tx.Model(&DraftMAWBItemDim{}).Where("draft_mawb_item_id IN (?)", pg.In(itemIDs)).Delete()
+		if err != nil {
+			return utils.PostgresErrorTransform(err)
+		}
+	}
+
+	_, err = tx.Model(&DraftMAWBItem{}).Where("draft_mawb_uuid = ?", draftUUID).Delete()
+	if err != nil {
+		return utils.PostgresErrorTransform(err)
+	}
+
+	_, err = tx.Model(&DraftMAWBCharge{}).Where("draft_mawb_uuid = ?", draftUUID).Delete()
+	if err != nil {
+		return utils.PostgresErrorTransform(err)
+	}
+
+	return nil
+}
+
+func (r *draftMAWBRepository) createTablesIfNotExists(ctx context.Context, db orm.DB) error {
+	queries := []string{
+		`CREATE TABLE IF NOT EXISTS draft_mawb (
+			uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			mawb_info_uuid UUID NOT NULL,
+			customer_uuid UUID,
+			airline_logo VARCHAR(500),
+			airline_name VARCHAR(255),
+			mawb VARCHAR(255),
+			hawb VARCHAR(255),
+			shipper_name_and_address TEXT,
+			awb_issued_by VARCHAR(255),
+			consignee_name_and_address TEXT,
+			issuing_carrier_agent_name VARCHAR(255),
+			accounting_infomation TEXT,
+			agents_iata_code VARCHAR(50),
+			account_no VARCHAR(100),
+			airport_of_departure VARCHAR(100),
+			reference_number VARCHAR(100),
+			optional_shipping_info1 VARCHAR(255),
+			optional_shipping_info2 VARCHAR(255),
+			routing_to VARCHAR(100),
+			routing_by VARCHAR(100),
+			destination_to1 VARCHAR(100),
+			destination_by1 VARCHAR(100),
+			destination_to2 VARCHAR(100),
+			destination_by2 VARCHAR(100),
+			currency VARCHAR(10),
+			chgs_code VARCHAR(10),
+			wt_val_ppd VARCHAR(10),
+			wt_val_coll VARCHAR(10),
+			other_ppd VARCHAR(10),
+			other_coll VARCHAR(10),
+			declared_val_carriage VARCHAR(100),
+			declared_val_customs VARCHAR(100),
+			airport_of_destination VARCHAR(100),
+			requested_flight_date1 VARCHAR(100),
+			requested_flight_date2 VARCHAR(100),
+			amount_of_insurance VARCHAR(100),
+			handling_infomation TEXT,
+			sci VARCHAR(255),
+			prepaid DECIMAL(10,2) DEFAULT 0,
+			valuation_charge DECIMAL(10,2) DEFAULT 0,
+			tax DECIMAL(10,2) DEFAULT 0,
+			total_other_charges_due_agent DECIMAL(10,2) DEFAULT 0,
+			total_other_charges_due_carrier DECIMAL(10,2) DEFAULT 0,
+			total_prepaid DECIMAL(10,2) DEFAULT 0,
+			currency_conversion_rates VARCHAR(255),
+			signature1 VARCHAR(255),
+			signature2_date DATE,
+			signature2_place VARCHAR(255),
+			signature2_issuing VARCHAR(255),
+			shipping_mark TEXT,
+			status VARCHAR(50) DEFAULT 'Draft',
+			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			CONSTRAINT fk_mawb_info
+				FOREIGN KEY(mawb_info_uuid)
+				REFERENCES tbl_mawb_info(uuid)
+				ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_draft_mawb_mawb_info_uuid ON draft_mawb(mawb_info_uuid)`,
+		`CREATE TABLE IF NOT EXISTS draft_mawb_items (
+			id SERIAL PRIMARY KEY,
+			draft_mawb_uuid UUID NOT NULL,
+			pieces_rcp VARCHAR(100),
+			gross_weight VARCHAR(100),
+			kg_lb VARCHAR(10) DEFAULT 'kg',
+			rate_class VARCHAR(255),
+			total_volume VARCHAR(100),
+			chargeable_weight VARCHAR(100),
+			rate_charge DECIMAL(10,2) DEFAULT 0,
+			total DECIMAL(10,2) DEFAULT 0,
+			nature_and_quantity TEXT,
+			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			CONSTRAINT fk_draft_mawb
+				FOREIGN KEY(draft_mawb_uuid)
+				REFERENCES draft_mawb(uuid)
+				ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_draft_mawb_items_uuid ON draft_mawb_items(draft_mawb_uuid)`,
+		`CREATE TABLE IF NOT EXISTS draft_mawb_item_dims (
+			id SERIAL PRIMARY KEY,
+			draft_mawb_item_id INT NOT NULL,
+			length VARCHAR(50),
+			width VARCHAR(50),
+			height VARCHAR(50),
+			count VARCHAR(50),
+			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			CONSTRAINT fk_draft_mawb_item
+				FOREIGN KEY(draft_mawb_item_id)
+				REFERENCES draft_mawb_items(id)
+				ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_draft_mawb_item_dims_item_id ON draft_mawb_item_dims(draft_mawb_item_id)`,
+		`CREATE TABLE IF NOT EXISTS draft_mawb_charges (
+			id SERIAL PRIMARY KEY,
+			draft_mawb_uuid UUID NOT NULL,
+			charge_key VARCHAR(255),
+			charge_value DECIMAL(10,2) DEFAULT 0,
+			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			CONSTRAINT fk_draft_mawb
+				FOREIGN KEY(draft_mawb_uuid)
+				REFERENCES draft_mawb(uuid)
+				ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_draft_mawb_charges_uuid ON draft_mawb_charges(draft_mawb_uuid)`,
+	}
+	for _, query := range queries {
+		_, err := db.Exec(query)
+		if err != nil {
+			return utils.PostgresErrorTransform(err)
+		}
+	}
+	return nil
+}

--- a/outbound/mawbinfo/draft_mawb_service.go
+++ b/outbound/mawbinfo/draft_mawb_service.go
@@ -1,0 +1,192 @@
+package mawbinfo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-playground/validator"
+)
+
+type DraftMAWBService interface {
+	GetDraftMAWB(ctx context.Context, mawbInfoUUID string) (*DraftMAWB, error)
+	CreateOrUpdateDraftMAWB(ctx context.Context, mawbInfoUUID string, req *DraftMAWB) (*DraftMAWB, error)
+	UpdateDraftMAWBStatus(ctx context.Context, mawbInfoUUID, status string) error
+}
+
+type draftMAWBService struct {
+	mawbInfoRepo  Repository
+	draftMAWBRepo DraftMAWBRepository
+	contextTimeout time.Duration
+	validate      *validator.Validate
+}
+
+func NewDraftMAWBService(
+	mawbInfoRepo Repository,
+	draftMAWBRepo DraftMAWBRepository,
+	timeout time.Duration,
+) DraftMAWBService {
+	return &draftMAWBService{
+		mawbInfoRepo:   mawbInfoRepo,
+		draftMAWBRepo:  draftMAWBRepo,
+		contextTimeout: timeout,
+		validate:       validator.New(),
+	}
+}
+
+func (s *draftMAWBService) GetDraftMAWB(ctx context.Context, mawbInfoUUID string) (*DraftMAWB, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(mawbInfoUUID) == "" {
+		return nil, errors.New("mawb info uuid is required")
+	}
+
+	draft, err := s.draftMAWBRepo.GetByMAWBInfoUUID(ctx, mawbInfoUUID)
+	if err != nil {
+		return nil, err
+	}
+	if draft == nil {
+		return nil, sql.ErrNoRows
+	}
+
+	return draft, nil
+}
+
+func (s *draftMAWBService) CreateOrUpdateDraftMAWB(ctx context.Context, mawbInfoUUID string, req *DraftMAWB) (*DraftMAWB, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(mawbInfoUUID) == "" {
+		return nil, errors.New("mawb info uuid is required")
+	}
+
+	// 1. Validate that the MAWB Info record exists
+	_, err := s.mawbInfoRepo.GetMawbInfo(ctx, mawbInfoUUID)
+	if err != nil {
+		if err == sql.ErrNoRows || strings.Contains(err.Error(), "no rows") {
+			return nil, errors.New("mawb info not found")
+		}
+		return nil, err
+	}
+
+	// 2. Validate the request body
+	if err := s.validate.Struct(req); err != nil {
+		return nil, err
+	}
+
+	// 3. Perform calculations
+	s.calculateAll(req)
+
+	// 4. Set the UUID from the path and pass to repository
+	req.MAWBInfoUUID = mawbInfoUUID
+	req.Status = "Draft"
+
+	result, err := s.draftMAWBRepo.CreateOrUpdate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *draftMAWBService) UpdateDraftMAWBStatus(ctx context.Context, mawbInfoUUID, status string) error {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(mawbInfoUUID) == "" {
+		return errors.New("mawb info uuid is required")
+	}
+
+	validStatuses := map[string]bool{"Confirmed": true, "Rejected": true}
+	if !validStatuses[status] {
+		return errors.New("invalid status provided")
+	}
+
+	_, err := s.mawbInfoRepo.GetMawbInfo(ctx, mawbInfoUUID)
+	if err != nil {
+		if err == sql.ErrNoRows || strings.Contains(err.Error(), "no rows") {
+			return errors.New("mawb info not found")
+		}
+		return err
+	}
+
+	err = s.draftMAWBRepo.UpdateStatus(ctx, mawbInfoUUID, status)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return errors.New("draft mawb not found for this mawb")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (s *draftMAWBService) calculateAll(draft *DraftMAWB) {
+	for i := range draft.Items {
+		item := &draft.Items[i]
+		totalVolume, chargeableWeight := s.calculateVolumeAndChargeableWeight(item.Dims, item.GrossWeight, item.KgLb)
+		item.TotalVolume = totalVolume
+		item.ChargeableWeight = chargeableWeight
+
+		// Calculate total for the item
+		rateCharge, _ := item.RateCharge, 10
+		chargeableWeightFloat, _ := strconv.ParseFloat(chargeableWeight, 64)
+		item.Total = rateCharge * chargeableWeightFloat
+	}
+
+	s.calculateTotals(draft)
+}
+
+func (s *draftMAWBService) calculateVolumeAndChargeableWeight(dims []DraftMAWBItemDim, grossWeightStr string, kgLb string) (string, string) {
+	var totalVolume float64
+
+	for _, dim := range dims {
+		length, _ := strconv.ParseFloat(dim.Length, 64)
+		width, _ := strconv.ParseFloat(dim.Width, 64)
+		height, _ := strconv.ParseFloat(dim.Height, 64)
+		count, _ := strconv.ParseFloat(dim.Count, 64)
+
+		if length > 0 && width > 0 && height > 0 && count > 0 {
+			volume := (length * width * height) / 1000000 // cm³ to m³
+			totalVolume += volume * count
+		}
+	}
+
+	volumetricWeight := totalVolume * 166.67
+	weight, _ := strconv.ParseFloat(grossWeightStr, 64)
+
+	if kgLb == "lb" {
+		weight = weight * 0.453592 // Convert lb to kg
+	}
+
+	chargeableWeight := math.Max(weight, volumetricWeight)
+
+	return fmt.Sprintf("%.3f", totalVolume), fmt.Sprintf("%.2f", chargeableWeight)
+}
+
+func (s *draftMAWBService) calculateTotals(draft *DraftMAWB) {
+	var totalOtherChargesDueCarrier float64
+	for _, charge := range draft.Charges {
+		totalOtherChargesDueCarrier += charge.Value
+	}
+
+	var totalItemCharges float64
+	for i := range draft.Items {
+		totalItemCharges += draft.Items[i].Total
+	}
+
+	// According to requirement, this seems to be the sum of item totals and explicit charges
+	draft.TotalOtherChargesDueCarrier = totalItemCharges + totalOtherChargesDueCarrier
+
+	draft.TotalPrepaid = draft.Prepaid +
+		draft.ValuationCharge +
+		draft.Tax +
+		draft.TotalOtherChargesDueAgent +
+		draft.TotalOtherChargesDueCarrier
+}

--- a/server/server.go
+++ b/server/server.go
@@ -138,7 +138,11 @@ func New(
 			dropdownSvc := dropdownHandler{s.svcFactory.DropdownSvc}
 			r.Mount("/dropdown", dropdownSvc.router())
 
-			mawbInfoSvc := mawbInfoHandler{s.svcFactory.MawbInfoSvc}
+			mawbInfoSvc := mawbInfoHandler{
+				s:                s.svcFactory.MawbInfoSvc,
+				cargoManifestSvc: s.svcFactory.CargoManifestSvc,
+				draftMAWBSvc:     s.svcFactory.DraftMAWBSvc,
+			}
 			r.Mount("/mawbinfo", mawbInfoSvc.router())
 
 			compareSvc := excelHandler{s.svcFactory.CompareSvc}


### PR DESCRIPTION
This commit introduces new API endpoints to manage Cargo Manifests and Draft MAWBs, linking them to the existing MAWB Info module.

The implementation follows the specifications outlined in the backend_api_requirements.md document.

Key changes include:
- Addition of new API endpoints under `/v1/mawbinfo/{uuid}/` for `cargo-manifest` and `draft-mawb`.
- Creation of new database tables with foreign key relationships to `tbl_mawb_info`. The repositories include logic to create these tables if they don't exist, matching the existing application pattern.
- Implementation of service layers with business logic, including validation and calculations for chargeable weight and totals for Draft MAWBs.
- Handlers for all CRUD operations, status management (confirm/reject), and placeholder print endpoints.
- Integration of the new modules into the existing factory dependency injection framework.