### PR TITLE
feat: Implement Cargo Manifest and Draft MAWB APIs

### DIFF
--- a/outbound/mawbinfo/custom_types.go
+++ b/outbound/mawbinfo/custom_types.go
@@ -1,0 +1,45 @@
+package mawbinfo
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CustomDate is a wrapper around time.Time to handle custom date formats
+type CustomDate struct {
+	time.Time
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (cd *CustomDate) UnmarshalJSON(b []byte) (err error) {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" || s == "" {
+		return nil
+	}
+
+	// List of supported layouts
+	layouts := []string{
+		"2006-01-02", // YYYY-MM-DD
+		"02-01-2006", // DD-MM-YYYY
+		time.RFC3339,
+	}
+
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, s)
+		if err == nil {
+			cd.Time = t
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unable to parse date: %s", s)
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (cd CustomDate) MarshalJSON() ([]byte, error) {
+	if cd.IsZero() {
+		return []byte("null"), nil
+	}
+	return []byte(fmt.Sprintf("\"%s\"", cd.Format("2006-01-02"))), nil
+}

--- a/outbound/mawbinfo/draft_mawb.go
+++ b/outbound/mawbinfo/draft_mawb.go
@@ -52,7 +52,7 @@ type DraftMAWB struct {
 	TotalPrepaid                float64           `json:"totalPrepaid" db:"total_prepaid"`
 	CurrencyConversionRates     string            `json:"currencyConversionRates" db:"currency_conversion_rates"`
 	Signature1                  string            `json:"signature1" db:"signature1"`
-	Signature2Date              *time.Time        `json:"signature2Date" db:"signature2_date"`
+	Signature2Date              *CustomDate       `json:"signature2Date" db:"signature2_date"`
 	Signature2Place             string            `json:"signature2Place" db:"signature2_place"`
 	Signature2Issuing           string            `json:"signature2Issuing" db:"signature2_issuing"`
 	ShippingMark                string            `json:"shippingMark" db:"shipping_mark"`


### PR DESCRIPTION
This commit introduces new API endpoints to manage Cargo Manifests and Draft MAWBs, linking them to the existing MAWB Info module.

The implementation follows the specifications outlined in the backend_api_requirements.md document.

Key changes include:
- Addition of new API endpoints under `/v1/mawbinfo/{uuid}/` for `cargo-manifest` and `draft-mawb`.
- Creation of new database tables with foreign key relationships to `tbl_mawb_info`.
- Implementation of service layers with business logic, including validation and calculations for Draft MAWBs.
- Handlers for all CRUD operations, status management, and placeholder print endpoints.
- Integration of the new modules into the existing factory dependency injection framework.

fix: Correct date parsing for Draft MAWB API

This commit also resolves a bug in the Draft MAWB creation endpoint where dates in 'YYYY-MM-DD' format were causing a parsing error.

A custom `CustomDate` type with a flexible JSON unmarshaler has been introduced to handle various date formats (`YYYY-MM-DD`, `DD-MM-YYYY`) for the `signature2Date` field.