### PR TITLE
fix: Correct go-pg method calls in repositories

### DIFF
--- a/outbound/mawb/cargo_manifest_repository.go
+++ b/outbound/mawb/cargo_manifest_repository.go
@@ -158,11 +158,7 @@ func (r repository) UpdateCargoManifestStatus(ctx context.Context, mawbInfoUUID,
 		return err
 	}
 
-	rowsAffected, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rowsAffected == 0 {
+	if res.RowsAffected() == 0 {
 		return sql.ErrNoRows // Indicate that no record was updated
 	}
 

--- a/outbound/mawb/draft_repository_v2.go
+++ b/outbound/mawb/draft_repository_v2.go
@@ -128,7 +128,7 @@ func (r repository) CreateOrUpdateDraftMAWBV2(ctx context.Context, draft *DraftM
 	for _, item := range draft.Items {
 		var itemID int
 		itemQuery := `INSERT INTO draft_mawb_items (draft_mawb_uuid, pieces_rcp, gross_weight, nature_and_quantity) VALUES (?, ?, ?, ?) RETURNING id`
-		err := tx.QueryRowContext(ctx, &itemID, itemQuery, draft.UUID, item.PiecesRCP, item.GrossWeight, item.NatureAndQuantity)
+		_, err := tx.QueryOneContext(ctx, pg.Scan(&itemID), itemQuery, draft.UUID, item.PiecesRCP, item.GrossWeight, item.NatureAndQuantity)
 		if err != nil {
 			return nil, fmt.Errorf("inserting item: %w", err)
 		}
@@ -160,9 +160,7 @@ func (r repository) UpdateDraftMAWBStatusV2(ctx context.Context, mawbInfoUUID, s
 	if err != nil {
 		return err
 	}
-	if rows, err := res.RowsAffected(); err != nil {
-		return err
-	} else if rows == 0 {
+	if res.RowsAffected() == 0 {
 		return sql.ErrNoRows
 	}
 	return nil


### PR DESCRIPTION
This commit fixes several compilation errors that were present in the initial implementation. The errors were due to incorrect method calls for the go-pg database library.

- Replaced incorrect `tx.QueryRowContext` with the correct `tx.QueryOneContext` for fetching a single value in a transaction in `draft_repository_v2.go`.
- Corrected the usage of `res.RowsAffected()`. This method returns a single integer, not an error tuple. The execution error is handled by the preceding `ExecContext` call. This was fixed in both `cargo_manifest_repository.go` and `draft_repository_v2.go`.