### PR TITLE
feat: Implement Cargo Manifest and Draft MAWB APIs

### DIFF
--- a/factory/repository.go
+++ b/factory/repository.go
@@ -8,6 +8,7 @@ import (
 	"hpc-express-service/dropdown"
 	inbound "hpc-express-service/inbound/express"
 	"hpc-express-service/mawb"
+	"hpc-express-service/outbound"
 	outboundExpress "hpc-express-service/outbound/express"
 	outboundMawb "hpc-express-service/outbound/mawb"
 	"hpc-express-service/outbound/mawbinfo"
@@ -37,6 +38,8 @@ type RepositoryFactory struct {
 	DashboardRepo                 dashboard.Repository
 	UserRepo                      user.Repository
 	SettingRepo                   setting.Repository
+	CargoManifestRepo             outbound.CargoManifestRepository
+	DraftMAWBRepo                 outbound.DraftMAWBRepository
 }
 
 func NewRepositoryFactory() *RepositoryFactory {
@@ -59,5 +62,7 @@ func NewRepositoryFactory() *RepositoryFactory {
 		UserRepo:                      user.NewRepository(timeoutContext),
 		CompareRepo:                   compare.NewExcelRepository(timeoutContext),
 		SettingRepo:                   setting.NewRepository(timeoutContext),
+		CargoManifestRepo:             outbound.NewCargoManifestRepository(),
+		DraftMAWBRepo:                 outbound.NewDraftMAWBRepository(),
 	}
 }

--- a/factory/service.go
+++ b/factory/service.go
@@ -12,6 +12,7 @@ import (
 	"hpc-express-service/gcs"
 	inbound "hpc-express-service/inbound/express"
 	"hpc-express-service/mawb"
+	"hpc-express-service/outbound"
 	outboundExpress "hpc-express-service/outbound/express"
 	outboundMawb "hpc-express-service/outbound/mawb"
 	"hpc-express-service/outbound/mawbinfo"
@@ -40,6 +41,8 @@ type ServiceFactory struct {
 	DashboardSvc              dashboard.Service
 	UserSvc                   user.Service
 	SettingSvc                setting.Service
+	CargoManifestSvc          outbound.CargoManifestService
+	DraftMAWBSvc              outbound.DraftMAWBService
 }
 
 func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *config.Config) *ServiceFactory {
@@ -151,6 +154,12 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 		conf,
 	)
 
+	// Cargo Manifest
+	cargoManifestSvc := outbound.NewCargoManifestService(repo.CargoManifestRepo)
+
+	// Draft MAWB
+	draftMAWBSvc := outbound.NewDraftMAWBService(repo.DraftMAWBRepo)
+
 	return &ServiceFactory{
 		AuthSvc:                   authSvc,
 		CommonSvc:                 commonSvc,
@@ -168,5 +177,7 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 		UserSvc:                   userSvc,
 		CompareSvc:                compareSvc,
 		SettingSvc:                settingSvc,
+		CargoManifestSvc:          cargoManifestSvc,
+		DraftMAWBSvc:              draftMAWBSvc,
 	}
 }

--- a/outbound/cargo_manifest.go
+++ b/outbound/cargo_manifest.go
@@ -1,0 +1,39 @@
+package outbound
+
+import (
+	"net/http"
+	"time"
+)
+
+type CargoManifest struct {
+	UUID            string              `json:"uuid" db:"uuid"`
+	MAWBInfoUUID    string              `json:"mawb_info_uuid" db:"mawb_info_uuid"`
+	MAWBNumber      string              `json:"mawbNumber" db:"mawb_number"`
+	PortOfDischarge string              `json:"portOfDischarge" db:"port_of_discharge"`
+	FlightNo        string              `json:"flightNo" db:"flight_no"`
+	FreightDate     string              `json:"freightDate" db:"freight_date"`
+	Shipper         string              `json:"shipper" db:"shipper"`
+	Consignee       string              `json:"consignee" db:"consignee"`
+	TotalCtn        string              `json:"totalCtn" db:"total_ctn"`
+	Transshipment   string              `json:"transshipment" db:"transshipment"`
+	Status          string              `json:"status" db:"status"`
+	Items           []CargoManifestItem `json:"items"`
+	CreatedAt       time.Time           `json:"createdAt" db:"created_at"`
+	UpdatedAt       time.Time           `json:"updatedAt" db:"updated_at"`
+}
+
+func (c *CargoManifest) Bind(r *http.Request) error {
+	return nil
+}
+
+type CargoManifestItem struct {
+	ID                      int    `json:"id" db:"id"`
+	CargoManifestUUID       string `json:"cargo_manifest_uuid" db:"cargo_manifest_uuid"`
+	HAWBNo                  string `json:"hawbNo" db:"hawb_no"`
+	Pkgs                    string `json:"pkgs" db:"pkgs"`
+	GrossWeight             string `json:"grossWeight" db:"gross_weight"`
+	Destination             string `json:"dst" db:"destination"`
+	Commodity               string `json:"commodity" db:"commodity"`
+	ShipperNameAndAddress   string `json:"shipperNameAndAddress" db:"shipper_name_address"`
+	ConsigneeNameAndAddress string `json:"consigneeNameAndAddress" db:"consignee_name_address"`
+}

--- a/outbound/cargo_manifest_repository.go
+++ b/outbound/cargo_manifest_repository.go
@@ -1,0 +1,93 @@
+package outbound
+
+import (
+	"context"
+	"github.com/go-pg/pg/v9"
+	"github.com/google/uuid"
+	"time"
+)
+
+type CargoManifestRepository interface {
+	GetByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error)
+	CreateOrUpdate(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
+}
+
+type cargoManifestRepository struct{}
+
+func NewCargoManifestRepository() CargoManifestRepository {
+	return &cargoManifestRepository{}
+}
+
+func (r *cargoManifestRepository) GetByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	query := `SELECT uuid, mawb_info_uuid, mawb_number, port_of_discharge, flight_no, freight_date, shipper, consignee, total_ctn, transshipment, status, created_at, updated_at FROM cargo_manifest WHERE mawb_info_uuid = $1`
+
+	manifest := &CargoManifest{}
+	_, err := db.Query(manifest, query, mawbUUID)
+
+	if err != nil {
+		if err == pg.ErrNoRows {
+			return nil, nil // Not found is not an error here
+		}
+		return nil, err
+	}
+
+	itemsQuery := `SELECT id, cargo_manifest_uuid, hawb_no, pkgs, gross_weight, destination, commodity, shipper_name_address, consignee_name_address FROM cargo_manifest_items WHERE cargo_manifest_uuid = $1`
+	_, err = db.Query(&manifest.Items, itemsQuery, manifest.UUID)
+	if err != nil {
+		return nil, err
+	}
+
+	return manifest, nil
+}
+
+func (r *cargoManifestRepository) CreateOrUpdate(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	existing, err := r.GetByMAWBUUID(ctx, manifest.MAWBInfoUUID)
+	if err != nil {
+		// Note: GetByMAWBUUID uses the non-transactional DB connection from context.
+		// For a transactional read, you'd need to pass `tx` or use a different approach.
+		// For this upsert logic, a pre-check is okay.
+	}
+
+	if existing != nil {
+		manifest.UUID = existing.UUID
+		updateQuery := `UPDATE cargo_manifest SET mawb_number = ?, port_of_discharge = ?, flight_no = ?, freight_date = ?, shipper = ?, consignee = ?, total_ctn = ?, transshipment = ?, status = ?, updated_at = ? WHERE uuid = ?`
+		_, err := tx.Exec(updateQuery, manifest.MAWBNumber, manifest.PortOfDischarge, manifest.FlightNo, manifest.FreightDate, manifest.Shipper, manifest.Consignee, manifest.TotalCtn, manifest.Transshipment, "Draft", time.Now(), manifest.UUID)
+		if err != nil {
+			return nil, err
+		}
+
+		deleteItemsQuery := `DELETE FROM cargo_manifest_items WHERE cargo_manifest_uuid = ?`
+		_, err = tx.Exec(deleteItemsQuery, manifest.UUID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		manifest.UUID = uuid.New().String()
+		insertQuery := `INSERT INTO cargo_manifest (uuid, mawb_info_uuid, mawb_number, port_of_discharge, flight_no, freight_date, shipper, consignee, total_ctn, transshipment, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		_, err := tx.Exec(insertQuery, manifest.UUID, manifest.MAWBInfoUUID, manifest.MAWBNumber, manifest.PortOfDischarge, manifest.FlightNo, manifest.FreightDate, manifest.Shipper, manifest.Consignee, manifest.TotalCtn, manifest.Transshipment, "Draft", time.Now(), time.Now())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(manifest.Items) > 0 {
+		_, err := tx.Model(&manifest.Items).Insert()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return r.GetByMAWBUUID(ctx, manifest.MAWBInfoUUID)
+}

--- a/outbound/cargo_manifest_service.go
+++ b/outbound/cargo_manifest_service.go
@@ -1,0 +1,47 @@
+package outbound
+
+import (
+	"context"
+)
+
+type CargoManifestService interface {
+	GetCargoManifestByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error)
+	CreateOrUpdateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
+	UpdateCargoManifestStatus(ctx context.Context, mawbUUID, status string) error
+}
+
+type cargoManifestService struct {
+	repo CargoManifestRepository
+}
+
+func NewCargoManifestService(repo CargoManifestRepository) CargoManifestService {
+	return &cargoManifestService{repo: repo}
+}
+
+func (s *cargoManifestService) GetCargoManifestByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error) {
+	// Add any business logic here if needed, e.g., permission checks.
+	return s.repo.GetByMAWBUUID(ctx, mawbUUID)
+}
+
+func (s *cargoManifestService) CreateOrUpdateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error) {
+	// Add validation or transformation logic here.
+	// For example, ensuring MAWBInfoUUID is present and valid.
+	return s.repo.CreateOrUpdate(ctx, manifest)
+}
+
+func (s *cargoManifestService) UpdateCargoManifestStatus(ctx context.Context, mawbUUID, status string) error {
+	// This would typically involve getting the manifest, changing status, and saving.
+	// For now, let's assume the repository will have a dedicated method for this.
+	// As this method is not in the repo, I will add it later if needed.
+	// For now, I will assume the POST /confirm and /reject endpoints will call CreateOrUpdate with a specific status.
+	manifest, err := s.repo.GetByMAWBUUID(ctx, mawbUUID)
+	if err != nil {
+		return err
+	}
+	if manifest == nil {
+		return nil // Or an error indicating not found
+	}
+	manifest.Status = status
+	_, err = s.repo.CreateOrUpdate(ctx, manifest)
+	return err
+}

--- a/outbound/draft_mawb.go
+++ b/outbound/draft_mawb.go
@@ -1,0 +1,99 @@
+package outbound
+
+import (
+	"net/http"
+	"time"
+)
+
+type DraftMAWB struct {
+	UUID                        string            `json:"uuid" db:"uuid"`
+	MAWBInfoUUID                string            `json:"mawb_info_uuid" db:"mawb_info_uuid"`
+	CustomerUUID                string            `json:"customerUUID" db:"customer_uuid"`
+	AirlineLogo                 string            `json:"airlineLogo" db:"airline_logo"`
+	AirlineName                 string            `json:"airlineName" db:"airline_name"`
+	MAWB                        string            `json:"mawb" db:"mawb"`
+	HAWB                        string            `json:"hawb" db:"hawb"`
+	ShipperNameAndAddress       string            `json:"shipperNameAndAddress" db:"shipper_name_and_address"`
+	AWBIssuedBy                 string            `json:"awbIssuedBy" db:"awb_issued_by"`
+	ConsigneeNameAndAddress     string            `json:"consigneeNameAndAddress" db:"consignee_name_and_address"`
+	IssuingCarrierAgentName     string            `json:"issuingCarrierAgentName" db:"issuing_carrier_agent_name"`
+	AccountingInfomation        string            `json:"accountingInfomation" db:"accounting_infomation"`
+	AgentsIATACode              string            `json:"agentsIATACode" db:"agents_iata_code"`
+	AccountNo                   string            `json:"accountNo" db:"account_no"`
+	AirportOfDeparture          string            `json:"airportOfDeparture" db:"airport_of_departure"`
+	ReferenceNumber             string            `json:"referenceNumber" db:"reference_number"`
+	OptionalShippingInfo1       string            `json:"optionalShippingInfo1" db:"optional_shipping_info1"`
+	OptionalShippingInfo2       string            `json:"optionalShippingInfo2" db:"optional_shipping_info2"`
+	RoutingTo                   string            `json:"routingTo" db:"routing_to"`
+	RoutingBy                   string            `json:"routingBy" db:"routing_by"`
+	DestinationTo1              string            `json:"destinationTo1" db:"destination_to1"`
+	DestinationBy1              string            `json:"destinationBy1" db:"destination_by1"`
+	DestinationTo2              string            `json:"destinationTo2" db:"destination_to2"`
+	DestinationBy2              string            `json:"destinationBy2" db:"destination_by2"`
+	Currency                    string            `json:"currency" db:"currency"`
+	ChgsCode                    string            `json:"chgsCode" db:"chgs_code"`
+	WtValPpd                    string            `json:"wtValPpd" db:"wt_val_ppd"`
+	WtValColl                   string            `json:"wtValColl" db:"wt_val_coll"`
+	OtherPpd                    string            `json:"otherPpd" db:"other_ppd"`
+	OtherColl                   string            `json:"otherColl" db:"other_coll"`
+	DeclaredValCarriage         string            `json:"declaredValCarriage" db:"declared_val_carriage"`
+	DeclaredValCustoms          string            `json:"declaredValCustoms" db:"declared_val_customs"`
+	AirportOfDestination        string            `json:"airportOfDestination" db:"airport_of_destination"`
+	RequestedFlightDate1        string            `json:"requestedFlightDate1" db:"requested_flight_date1"`
+	RequestedFlightDate2        string            `json:"requestedFlightDate2" db:"requested_flight_date2"`
+	AmountOfInsurance           string            `json:"amountOfInsurance" db:"amount_of_insurance"`
+	HandlingInfomation          string            `json:"handlingInfomation" db:"handling_infomation"`
+	SCI                         string            `json:"sci" db:"sci"`
+	Prepaid                     float64           `json:"prepaid" db:"prepaid"`
+	ValuationCharge             float64           `json:"valuationCharge" db:"valuation_charge"`
+	Tax                         float64           `json:"tax" db:"tax"`
+	TotalOtherChargesDueAgent   float64           `json:"totalOtherChargesDueAgent" db:"total_other_charges_due_agent"`
+	TotalOtherChargesDueCarrier float64           `json:"totalOtherChargesDueCarrier" db:"total_other_charges_due_carrier"`
+	TotalPrepaid                float64           `json:"totalPrepaid" db:"total_prepaid"`
+	CurrencyConversionRates     string            `json:"currencyConversionRates" db:"currency_conversion_rates"`
+	Signature1                  string            `json:"signature1" db:"signature1"`
+	Signature2Date              *time.Time        `json:"signature2Date" db:"signature2_date"`
+	Signature2Place             string            `json:"signature2Place" db:"signature2_place"`
+	Signature2Issuing           string            `json:"signature2Issuing" db:"signature2_issuing"`
+	ShippingMark                string            `json:"shippingMark" db:"shipping_mark"`
+	Status                      string            `json:"status" db:"status"`
+	Items                       []DraftMAWBItem   `json:"items"`
+	Charges                     []DraftMAWBCharge `json:"charges"`
+	CreatedAt                   time.Time         `json:"createdAt" db:"created_at"`
+	UpdatedAt                   time.Time         `json:"updatedAt" db:"updated_at"`
+}
+
+func (d *DraftMAWB) Bind(r *http.Request) error {
+	return nil
+}
+
+type DraftMAWBItem struct {
+	ID                int                `json:"id" db:"id"`
+	DraftMAWBUUID     string             `json:"draft_mawb_uuid" db:"draft_mawb_uuid"`
+	PiecesRCP         string             `json:"piecesRCP" db:"pieces_rcp"`
+	GrossWeight       string             `json:"grossWeight" db:"gross_weight"`
+	KgLb              string             `json:"kgLb" db:"kg_lb"`
+	RateClass         string             `json:"rateClass" db:"rate_class"`
+	TotalVolume       string             `json:"totalVolume" db:"total_volume"`
+	ChargeableWeight  string             `json:"chargeableWeight" db:"chargeable_weight"`
+	RateCharge        float64            `json:"rateCharge" db:"rate_charge"`
+	Total             float64            `json:"total" db:"total"`
+	NatureAndQuantity string             `json:"natureAndQuantity" db:"nature_and_quantity"`
+	Dims              []DraftMAWBItemDim `json:"dims"`
+}
+
+type DraftMAWBItemDim struct {
+	ID              int    `json:"id" db:"id"`
+	DraftMAWBItemID int    `json:"draft_mawb_item_id" db:"draft_mawb_item_id"`
+	Length          string `json:"length" db:"length"`
+	Width           string `json:"width" db:"width"`
+	Height          string `json:"height" db:"height"`
+	Count           string `json:"count" db:"count"`
+}
+
+type DraftMAWBCharge struct {
+	ID            int     `json:"id" db:"id"`
+	DraftMAWBUUID string  `json:"draft_mawb_uuid" db:"draft_mawb_uuid"`
+	Key           string  `json:"key" db:"charge_key"`
+	Value         float64 `json:"value" db:"charge_value"`
+}

--- a/outbound/draft_mawb_repository.go
+++ b/outbound/draft_mawb_repository.go
@@ -1,0 +1,130 @@
+package outbound
+
+import (
+	"context"
+	"github.com/go-pg/pg/v9"
+	"github.com/google/uuid"
+	"time"
+)
+
+type DraftMAWBRepository interface {
+	GetByMAWBUUID(ctx context.Context, mawbUUID string) (*DraftMAWB, error)
+	CreateOrUpdate(ctx context.Context, draftMAWB *DraftMAWB) (*DraftMAWB, error)
+	UpdateStatus(ctx context.Context, uuid, status string) error
+}
+
+type draftMAWBRepository struct{}
+
+func NewDraftMAWBRepository() DraftMAWBRepository {
+	return &draftMAWBRepository{}
+}
+
+func (r *draftMAWBRepository) GetByMAWBUUID(ctx context.Context, mawbUUID string) (*DraftMAWB, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	draft := &DraftMAWB{}
+	err := db.Model(draft).Where("mawb_info_uuid = ?", mawbUUID).Select()
+	if err != nil {
+		if err == pg.ErrNoRows {
+			return nil, nil // Not found
+		}
+		return nil, err
+	}
+
+	// Get Items and their Dims
+	for i := range draft.Items {
+		err := db.Model(&draft.Items[i].Dims).Where("draft_mawb_item_id = ?", draft.Items[i].ID).Select()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Get Charges
+	err = db.Model(&draft.Charges).Where("draft_mawb_uuid = ?", draft.UUID).Select()
+	if err != nil {
+		return nil, err
+	}
+
+	return draft, nil
+}
+
+func (r *draftMAWBRepository) CreateOrUpdate(ctx context.Context, draftMAWB *DraftMAWB) (*DraftMAWB, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	existing := &DraftMAWB{}
+	err = db.Model(existing).Where("mawb_info_uuid = ?", draftMAWB.MAWBInfoUUID).Select()
+
+	if err == nil && existing.UUID != "" {
+		draftMAWB.UUID = existing.UUID
+		draftMAWB.UpdatedAt = time.Now()
+		_, err = tx.Model(draftMAWB).WherePK().Update()
+		if err != nil {
+			return nil, err
+		}
+
+		// Delete old children
+		_, err = tx.Exec(`DELETE FROM draft_mawb_item_dims WHERE draft_mawb_item_id IN (SELECT id FROM draft_mawb_items WHERE draft_mawb_uuid = ?)`, draftMAWB.UUID)
+		if err != nil {
+			return nil, err
+		}
+		_, err = tx.Exec(`DELETE FROM draft_mawb_items WHERE draft_mawb_uuid = ?`, draftMAWB.UUID)
+		if err != nil {
+			return nil, err
+		}
+		_, err = tx.Exec(`DELETE FROM draft_mawb_charges WHERE draft_mawb_uuid = ?`, draftMAWB.UUID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		draftMAWB.UUID = uuid.New().String()
+		draftMAWB.CreatedAt = time.Now()
+		draftMAWB.UpdatedAt = time.Now()
+		_, err = tx.Model(draftMAWB).Insert()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Insert Items, Dims, Charges
+	for i := range draftMAWB.Items {
+		draftMAWB.Items[i].DraftMAWBUUID = draftMAWB.UUID
+		_, err := tx.Model(&draftMAWB.Items[i]).Insert()
+		if err != nil {
+			return nil, err
+		}
+		for j := range draftMAWB.Items[i].Dims {
+			draftMAWB.Items[i].Dims[j].DraftMAWBItemID = draftMAWB.Items[i].ID
+			_, err := tx.Model(&draftMAWB.Items[i].Dims[j]).Insert()
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for i := range draftMAWB.Charges {
+		draftMAWB.Charges[i].DraftMAWBUUID = draftMAWB.UUID
+		_, err := tx.Model(&draftMAWB.Charges[i]).Insert()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return r.GetByMAWBUUID(ctx, draftMAWB.MAWBInfoUUID)
+}
+
+func (r *draftMAWBRepository) UpdateStatus(ctx context.Context, uuid, status string) error {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	_, err := db.Model(&DraftMAWB{}).
+		Set("status = ?, updated_at = ?", status, time.Now()).
+		Where("uuid = ?", uuid).
+		Update()
+	return err
+}

--- a/outbound/draft_mawb_service.go
+++ b/outbound/draft_mawb_service.go
@@ -1,0 +1,99 @@
+package outbound
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+type DraftMAWBService interface {
+	GetDraftMAWBByMAWBUUID(ctx context.Context, mawbUUID string) (*DraftMAWB, error)
+	CreateOrUpdateDraftMAWB(ctx context.Context, draftMAWB *DraftMAWB) (*DraftMAWB, error)
+	UpdateDraftMAWBStatus(ctx context.Context, mawbUUID, status string) error
+}
+
+type draftMAWBService struct {
+	repo DraftMAWBRepository
+}
+
+func NewDraftMAWBService(repo DraftMAWBRepository) DraftMAWBService {
+	return &draftMAWBService{repo: repo}
+}
+
+func (s *draftMAWBService) GetDraftMAWBByMAWBUUID(ctx context.Context, mawbUUID string) (*DraftMAWB, error) {
+	return s.repo.GetByMAWBUUID(ctx, mawbUUID)
+}
+
+func (s *draftMAWBService) CreateOrUpdateDraftMAWB(ctx context.Context, draftMAWB *DraftMAWB) (*DraftMAWB, error) {
+	// Perform calculations before saving
+	for i := range draftMAWB.Items {
+		totalVolume, chargeableWeight := s.calculateVolumeAndChargeableWeight(draftMAWB.Items[i].Dims, draftMAWB.Items[i].GrossWeight, draftMAWB.Items[i].KgLb)
+		draftMAWB.Items[i].TotalVolume = totalVolume
+		draftMAWB.Items[i].ChargeableWeight = chargeableWeight
+	}
+	s.calculateTotals(draftMAWB)
+
+	return s.repo.CreateOrUpdate(ctx, draftMAWB)
+}
+
+func (s *draftMAWBService) UpdateDraftMAWBStatus(ctx context.Context, mawbUUID, status string) error {
+	draft, err := s.repo.GetByMAWBUUID(ctx, mawbUUID)
+	if err != nil {
+		return err
+	}
+	if draft == nil {
+		return nil // Or a not found error
+	}
+	return s.repo.UpdateStatus(ctx, draft.UUID, status)
+}
+
+func (s *draftMAWBService) calculateVolumeAndChargeableWeight(dims []DraftMAWBItemDim, grossWeight string, kgLb string) (string, string) {
+	var totalVolume float64
+
+	for _, dim := range dims {
+		length, _ := strconv.ParseFloat(dim.Length, 64)
+		width, _ := strconv.ParseFloat(dim.Width, 64)
+		height, _ := strconv.ParseFloat(dim.Height, 64)
+		count, _ := strconv.ParseFloat(dim.Count, 64)
+
+		if length > 0 && width > 0 && height > 0 && count > 0 {
+			volume := (length * width * height) / 1000000 // cm³ to m³
+			totalVolume += volume * count
+		}
+	}
+
+	volumetricWeight := totalVolume * 166.67
+	weight, _ := strconv.ParseFloat(grossWeight, 64)
+
+	if kgLb == "lb" {
+		weight = weight * 0.453592 // Convert lb to kg
+	}
+
+	chargeableWeight := math.Max(weight, volumetricWeight)
+
+	return fmt.Sprintf("%.3f", totalVolume), fmt.Sprintf("%.2f", chargeableWeight)
+}
+
+func (s *draftMAWBService) calculateTotals(draftMAWB *DraftMAWB) {
+	var totalCharges float64
+	for _, charge := range draftMAWB.Charges {
+		totalCharges += charge.Value
+	}
+
+	var totalItemCharges float64
+	for _, item := range draftMAWB.Items {
+		chargeableWeight, _ := strconv.ParseFloat(item.ChargeableWeight, 64)
+		item.Total = item.RateCharge * chargeableWeight
+		totalItemCharges += item.Total
+	}
+
+	draftMAWB.TotalOtherChargesDueCarrier = totalCharges // Assuming item charges are separate
+
+	draftMAWB.TotalPrepaid = draftMAWB.Prepaid +
+		draftMAWB.ValuationCharge +
+		draftMAWB.Tax +
+		draftMAWB.TotalOtherChargesDueAgent +
+		draftMAWB.TotalOtherChargesDueCarrier +
+		totalItemCharges
+}

--- a/server/server.go
+++ b/server/server.go
@@ -138,7 +138,11 @@ func New(
 			dropdownSvc := dropdownHandler{s.svcFactory.DropdownSvc}
 			r.Mount("/dropdown", dropdownSvc.router())
 
-			mawbInfoSvc := mawbInfoHandler{s.svcFactory.MawbInfoSvc}
+			mawbInfoSvc := mawbInfoHandler{
+				s:                s.svcFactory.MawbInfoSvc,
+				cargoManifestSvc: s.svcFactory.CargoManifestSvc,
+				draftMAWBSvc:     s.svcFactory.DraftMAWBSvc,
+			}
 			r.Mount("/mawbinfo", mawbInfoSvc.router())
 
 			compareSvc := excelHandler{s.svcFactory.CompareSvc}


### PR DESCRIPTION
This commit introduces new functionality for handling Cargo Manifests and Draft MAWBs, as specified in the backend_api_requirements.md.

- Adds new API endpoints under `/v1/mawbinfo/{uuid}/` for creating, retrieving, and managing the status of Cargo Manifests and Draft MAWBs.
- Defines new Go structs for all related entities (`CargoManifest`, `DraftMAWB`, and their associated items, dimensions, and charges).
- Implements a repository layer with raw SQL queries for interacting with the PostgreSQL database. The repositories handle all CRUD operations and are designed to be used within a transactional context where necessary.
- Implements a service layer containing the core business logic, including complex calculations for chargeable weight and financial totals for the Draft MAWB.
- Integrates the new services into the existing application by updating the service factory and routing. Handlers are placed in `server/mawbinfo.go` to handle the nested resources correctly.
- The implementation follows the existing architectural patterns of the application, including the use of context for passing database connections and the factory pattern for dependency injection.