### PR TITLE
fix: Correct repository implementation and startup issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,9 +38,12 @@ func main() {
 	// GCS
 	gcsClient, err := storage.NewClient(ctx)
 	if err != nil {
-		dlog.Fatalf("Failed to create GCS client: %v", err)
+		dlog.Printf("WARNING: Failed to create GCS client: %v. GCS functionality will be disabled.", err)
 	}
-	_gcs := gcs.InitialGCSClient(config.GCSProjectID, config.GCSBucketName, gcsClient)
+	var _gcs *gcs.Client
+	if gcsClient != nil {
+		_gcs = gcs.InitialGCSClient(config.GCSProjectID, config.GCSBucketName, gcsClient)
+	}
 
 	// PostgreSQL
 	postgreSQLConn, err := database.NewPostgreSQLConnection(

--- a/outbound/mawb/info_service.go
+++ b/outbound/mawb/info_service.go
@@ -97,6 +97,9 @@ func (s *service) UploadAttachment(ctx context.Context, uuid, fileOriginName str
 			contentType = "application/pdf"
 		}
 
+		if s.gcsClient == nil {
+			return fmt.Errorf("GCS client is not initialized")
+		}
 		_, _, err := s.gcsClient.UploadToGCS(ctx, bytes.NewReader(fileBytes), fullPath, true, contentType)
 		if err != nil {
 			log.Println("err", err)

--- a/uploadlog/service.go
+++ b/uploadlog/service.go
@@ -72,6 +72,9 @@ func (s *service) UploadLogFile(ctx context.Context, data *UploadFileModel) (str
 	// Determine content type
 	contentType := "application/octet-stream" // default
 
+	if s.gcsClient == nil {
+		return "", fmt.Errorf("GCS client is not initialized")
+	}
 	_, objAttrs, err := s.gcsClient.UploadToGCS(ctx, bytes.NewReader(data.FileBytes), fullPath, true, contentType)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This commit fixes several issues found after the initial implementation of the Cargo Manifest and Draft MAWB APIs.

- Replaces raw SQL queries in repositories with the `go-pg` ORM to ensure correct placeholder syntax and improve code quality. This resolves the `ERROR #42P02 there is no parameter $1` bug.
- Adds the `Bind()` method to `CargoManifest` and `DraftMAWB` structs to satisfy the `render.Binder` interface, fixing a compilation error.
- Modifies the GCS client initialization in `main.go` to be more resilient to missing credentials in a development environment, preventing the application from crashing on startup.
- Adds nil checks in services that consume the GCS client to prevent panics if the client fails to initialize.