### PR TITLE
feat: Integrate GCS for MAWB info attachment uploads

### DIFF
--- a/factory/service.go
+++ b/factory/service.go
@@ -105,6 +105,7 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 	// MawbInfo
 	mawbInfoSvc := mawbinfo.NewService(
 		repo.MawbInfoRepo,
+		gcsClient,
 		timeoutContext,
 	)
 	/*


### PR DESCRIPTION
Replaces the local file storage implementation for MAWB info attachments with a new implementation that uploads files to Google Cloud Storage (GCS).

- The `mawbinfo` service now uses the existing GCS client to upload files.
- The `UploadToGCS` function in the GCS utility was improved to directly return the public URL.
- The handler and repository layers required no changes, as they were already prepared for this data flow.