### PR TITLE
hotfix: Resolve runtime panic in GetDefaultStatusByType

### DIFF
--- a/setting/master_status_repository.go
+++ b/setting/master_status_repository.go
@@ -85,7 +85,7 @@ func (r *masterStatusRepository) GetDefaultStatusByType(ctx context.Context, sta
 		return nil, err
 	}
 	status := new(MasterStatus)
-	err = db.ModelContext(ctx, status).Where("type = ?", statusType).Where("is_default = ?", true).First()
+	_, err = db.QueryOne(status, `SELECT * FROM master_statuses WHERE type = ? AND is_default = true LIMIT 1`, statusType)
 	return status, err
 }
 


### PR DESCRIPTION
This commit provides a critical fix for a runtime panic and consolidates all previous refactoring work.

NOTE: This work is a departure from the original issue description. The scope of the task evolved through iterative user feedback to address several backend bugs, refactoring, and finally this runtime panic.

The runtime panic (`slice bounds out of range`) was traced to the `go-pg` ORM's `First()` method when used with a transaction context in the `setting` repository. The fix is to rewrite the `GetDefaultStatusByType` function to use a direct, raw SQL query with `db.QueryOne`, which bypasses the ORM's model-building logic that was causing the panic.