### PR TITLE
fix: Handle chargeableWeight as string to prevent pg error

### DIFF
--- a/outbound/mawbinfo/repository.go
+++ b/outbound/mawbinfo/repository.go
@@ -14,10 +14,10 @@ import (
 )
 
 type Repository interface {
-	CreateMawbInfo(ctx context.Context, data *CreateMawbInfoRequest, chargeableWeight float64) (*MawbInfoResponse, error)
+	CreateMawbInfo(ctx context.Context, data *CreateMawbInfoRequest, chargeableWeight string) (*MawbInfoResponse, error)
 	GetMawbInfo(ctx context.Context, uuid string) (*MawbInfoResponse, error)
 	GetAllMawbInfo(ctx context.Context, startDate, endDate string) ([]*MawbInfoResponse, error)
-	UpdateMawbInfo(ctx context.Context, uuid string, data *UpdateMawbInfoRequest, chargeableWeight float64, attachments []AttachmentInfo) (*MawbInfoResponse, error)
+	UpdateMawbInfo(ctx context.Context, uuid string, data *UpdateMawbInfoRequest, chargeableWeight string, attachments []AttachmentInfo) (*MawbInfoResponse, error)
 	DeleteMawbInfo(ctx context.Context, uuid string) error
 	DeleteMawbInfoAttachment(ctx context.Context, uuid string, fileName string) (*AttachmentInfo, error)
 	IsMawbExists(ctx context.Context, mawb string, uuid string) (bool, error)
@@ -35,7 +35,7 @@ func NewRepository(
 	}
 }
 
-func (r repository) CreateMawbInfo(ctx context.Context, data *CreateMawbInfoRequest, chargeableWeight float64) (*MawbInfoResponse, error) {
+func (r repository) CreateMawbInfo(ctx context.Context, data *CreateMawbInfoRequest, chargeableWeight string) (*MawbInfoResponse, error) {
 	db, err := utils.GetQuerier(ctx)
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (r repository) GetAllMawbInfo(ctx context.Context, startDate, endDate strin
 	return responses, nil
 }
 
-func (r repository) UpdateMawbInfo(ctx context.Context, uuid string, data *UpdateMawbInfoRequest, chargeableWeight float64, attachments []AttachmentInfo) (*MawbInfoResponse, error) {
+func (r repository) UpdateMawbInfo(ctx context.Context, uuid string, data *UpdateMawbInfoRequest, chargeableWeight string, attachments []AttachmentInfo) (*MawbInfoResponse, error) {
 	db, err := utils.GetQuerier(ctx)
 	if err != nil {
 		return nil, err

--- a/outbound/mawbinfo/service.go
+++ b/outbound/mawbinfo/service.go
@@ -264,19 +264,20 @@ func (s *service) validateUpdateInput(data *UpdateMawbInfoRequest) error {
 	return nil
 }
 
-func (s *service) convertChargeableWeight(weightStr string) (float64, error) {
+func (s *service) convertChargeableWeight(weightStr string) (string, error) {
 	weightStr = strings.TrimSpace(weightStr)
 	if weightStr == "" {
-		return 0, errors.New("chargeableWeight cannot be empty")
+		return "", errors.New("chargeableWeight cannot be empty")
 	}
 	weight, err := strconv.ParseFloat(weightStr, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid chargeableWeight format: %s", weightStr)
+		return "", fmt.Errorf("invalid chargeableWeight format: %s", weightStr)
 	}
 	if weight < 0 {
-		return 0, errors.New("chargeableWeight cannot be negative")
+		return "", errors.New("chargeableWeight cannot be negative")
 	}
-	return math.Round(weight*100) / 100, nil
+	// return math.Round(weight*100) / 100, nil
+	return fmt.Sprintf("%.2f", weight), nil
 }
 
 func (s *service) validateDateFormat(dateStr string) error {


### PR DESCRIPTION
The database driver was throwing a "pg: can't append float64" error because it could not handle the float64 type for a DECIMAL column.

This commit changes the `chargeableWeight` to be handled as a string when passed to the repository. The service layer now converts the input string to a validated and rounded string with two decimal places. This avoids the type issue with the `go-pg` library.