### PR TITLE
Fix: Make database repositories transaction-aware

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -1,4 +1,4 @@
-package outbound
+package common
 
 import (
 	"context"
@@ -8,8 +8,8 @@ import (
 	"github.com/go-pg/pg/v9/orm"
 )
 
-// qer สามารถเป็นได้ทั้ง *pg.DB และ *pg.Tx
-type qer interface {
+// Qer can be either a *pg.DB or a *pg.Tx
+type Qer interface {
 	Model(...interface{}) *orm.Query
 	Query(model, query interface{}, params ...interface{}) (orm.Result, error)
 	QueryOne(model, query interface{}, params ...interface{}) (orm.Result, error)
@@ -17,7 +17,7 @@ type qer interface {
 	ExecOne(query interface{}, params ...interface{}) (orm.Result, error)
 }
 
-func getQer(ctx context.Context) (qer, error) {
+func GetQer(ctx context.Context) (Qer, error) {
 	v := ctx.Value("postgreSQLConn")
 	switch db := v.(type) {
 	case *pg.DB:

--- a/common/repository.go
+++ b/common/repository.go
@@ -3,8 +3,6 @@ package common
 import (
 	"context"
 	"time"
-
-	"github.com/go-pg/pg/v9"
 )
 
 type Repository interface {
@@ -25,8 +23,11 @@ func NewRepository(
 }
 
 func (r repository) GetAllExchangeRates(ctx context.Context) ([]*GetExchangeRateModel, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
-	ctx, _ = context.WithTimeout(context.Background(), 5*time.Second)
+	db, err := GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	sqlStr := `
 		SELECT 
 			cxr."id",
@@ -47,7 +48,7 @@ func (r repository) GetAllExchangeRates(ctx context.Context) ([]*GetExchangeRate
 	`
 
 	var list []*GetExchangeRateModel
-	_, err := db.QueryContext(ctx, &list, sqlStr)
+	_, err = db.Query(&list, sqlStr)
 
 	if err != nil {
 		return list, err
@@ -57,8 +58,10 @@ func (r repository) GetAllExchangeRates(ctx context.Context) ([]*GetExchangeRate
 }
 
 func (r repository) GetAllConvertTemplates(ctx context.Context, category string) ([]*GetAllConvertTemplateModel, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
-	ctx, _ = context.WithTimeout(context.Background(), 5*time.Second)
+	db, err := GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
 	sqlStr := `select code, "name", "type" from master_convert_templates where deleted_at is null`
 
 	values := []interface{}{}
@@ -71,7 +74,7 @@ func (r repository) GetAllConvertTemplates(ctx context.Context, category string)
 	}
 
 	var list []*GetAllConvertTemplateModel
-	_, err := db.QueryContext(ctx, &list, sqlStr, values...)
+	_, err = db.Query(&list, sqlStr, values...)
 
 	if err != nil {
 		return list, err

--- a/outbound/cargo_manifest_repository.go
+++ b/outbound/cargo_manifest_repository.go
@@ -2,6 +2,7 @@ package outbound
 
 import (
 	"context"
+	"hpc-express-service/common"
 	"time"
 
 	"github.com/go-pg/pg/v9"
@@ -21,7 +22,7 @@ func NewCargoManifestRepository() CargoManifestRepository {
 }
 
 func (r *cargoManifestRepository) GetByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error) {
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +53,7 @@ func (r *cargoManifestRepository) GetByMAWBUUID(ctx context.Context, mawbUUID st
 }
 
 func (r *cargoManifestRepository) Create(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error) {
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +83,7 @@ func (r *cargoManifestRepository) Create(ctx context.Context, manifest *CargoMan
 }
 
 func (r *cargoManifestRepository) Update(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error) {
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/outbound/cargo_manifest_service.go
+++ b/outbound/cargo_manifest_service.go
@@ -3,6 +3,7 @@ package outbound
 import (
 	"context"
 	"fmt"
+	"hpc-express-service/common"
 	"hpc-express-service/setting"
 )
 
@@ -41,7 +42,7 @@ func (s *cargoManifestService) setDefaultStatus(ctx context.Context, manifest *C
 }
 
 func (s *cargoManifestService) CreateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error) {
-	tx, txCtx, err := BeginTx(ctx)
+	tx, txCtx, err := common.BeginTx(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +73,7 @@ func (s *cargoManifestService) CreateCargoManifest(ctx context.Context, manifest
 }
 
 func (s *cargoManifestService) UpdateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error) {
-	tx, txCtx, err := BeginTx(ctx)
+	tx, txCtx, err := common.BeginTx(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -89,10 +90,7 @@ func (s *cargoManifestService) UpdateCargoManifest(ctx context.Context, manifest
 
 	// Set the UUID from existing record for update
 	manifest.UUID = existing.UUID
-
-	if err := s.setDefaultStatus(txCtx, manifest); err != nil {
-		return nil, err
-	}
+	manifest.StatusUUID = existing.StatusUUID
 
 	result, err := s.repo.Update(txCtx, manifest)
 	if err != nil {
@@ -106,7 +104,7 @@ func (s *cargoManifestService) UpdateCargoManifest(ctx context.Context, manifest
 }
 
 func (s *cargoManifestService) UpdateCargoManifestStatus(ctx context.Context, mawbUUID, statusUUID string) error {
-	tx, txCtx, err := BeginTx(ctx)
+	tx, txCtx, err := common.BeginTx(ctx)
 	if err != nil {
 		return err
 	}

--- a/outbound/draft_mawb_repository.go
+++ b/outbound/draft_mawb_repository.go
@@ -3,6 +3,7 @@ package outbound
 import (
 	"context"
 	"fmt"
+	"hpc-express-service/common"
 	"strings"
 	"time"
 
@@ -28,7 +29,7 @@ func NewDraftMAWBRepository() DraftMAWBRepository {
 }
 
 func (r *draftMAWBRepository) GetByMAWBUUID(ctx context.Context, mawbUUID string) (*DraftMAWB, error) {
-	q, err := getQer(ctx)
+	q, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +53,7 @@ func (r *draftMAWBRepository) GetByMAWBUUID(ctx context.Context, mawbUUID string
 }
 
 func (r *draftMAWBRepository) GetByUUID(ctx context.Context, uuid string) (*DraftMAWB, error) {
-	q, err := getQer(ctx)
+	q, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +78,7 @@ func (r *draftMAWBRepository) GetByUUID(ctx context.Context, uuid string) (*Draf
 
 // UpdateStatus updates the status of a draft MAWB.
 func (r *draftMAWBRepository) UpdateStatus(ctx context.Context, uuid, statusUUID string) error {
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return err
 	}
@@ -90,7 +91,7 @@ func (r *draftMAWBRepository) UpdateStatus(ctx context.Context, uuid, statusUUID
 
 // GetAll retrieves all draft MAWB records with customer information and date filtering
 func (r *draftMAWBRepository) GetAll(ctx context.Context, startDate, endDate string) ([]DraftMAWBListItem, error) {
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func (r *draftMAWBRepository) GetAll(ctx context.Context, startDate, endDate str
 
 // CreateWithRelations creates a new draft MAWB with its items and charges within a transaction.
 func (r *draftMAWBRepository) CreateWithRelations(ctx context.Context, draftMAWB *DraftMAWB, items []DraftMAWBItemInput, charges []DraftMAWBChargeInput) (*DraftMAWB, error) {
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +236,7 @@ func (r *draftMAWBRepository) CreateWithRelations(ctx context.Context, draftMAWB
 
 // UpdateWithRelations updates an existing draft MAWB with its items and charges within a transaction.
 func (r *draftMAWBRepository) UpdateWithRelations(ctx context.Context, draftMAWB *DraftMAWB, items []DraftMAWBItemInput, charges []DraftMAWBChargeInput) (*DraftMAWB, error) {
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (r *draftMAWBRepository) GetWithRelations(ctx context.Context, uuid string)
 		return nil, err
 	}
 
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +372,7 @@ func (r *draftMAWBRepository) GetWithRelationsByMAWBUUID(ctx context.Context, ma
 		return nil, err
 	}
 
-	db, err := getQer(ctx)
+	db, err := common.GetQer(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/outbound/draft_mawb_service.go
+++ b/outbound/draft_mawb_service.go
@@ -3,6 +3,7 @@ package outbound
 import (
 	"context"
 	"fmt"
+	"hpc-express-service/common"
 	"hpc-express-service/setting"
 )
 
@@ -50,7 +51,7 @@ func (s *draftMAWBService) setDefaultStatus(ctx context.Context, draftMAWB *Draf
 }
 
 func (s *draftMAWBService) CreateDraftMAWB(ctx context.Context, draftMAWB *DraftMAWB, items []DraftMAWBItemInput, charges []DraftMAWBChargeInput) (*DraftMAWB, error) {
-	tx, txCtx, err := BeginTx(ctx)
+	tx, txCtx, err := common.BeginTx(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +74,7 @@ func (s *draftMAWBService) CreateDraftMAWB(ctx context.Context, draftMAWB *Draft
 }
 
 func (s *draftMAWBService) UpdateDraftMAWB(ctx context.Context, draftMAWB *DraftMAWB, items []DraftMAWBItemInput, charges []DraftMAWBChargeInput) (*DraftMAWB, error) {
-	tx, txCtx, err := BeginTx(ctx)
+	tx, txCtx, err := common.BeginTx(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func (s *draftMAWBService) UpdateDraftMAWB(ctx context.Context, draftMAWB *Draft
 	return result, nil
 }
 func (s *draftMAWBService) UpdateDraftMAWBStatus(ctx context.Context, mawbUUID, statusUUID string) error {
-	tx, txCtx, err := BeginTx(ctx)
+	tx, txCtx, err := common.BeginTx(ctx)
 	if err != nil {
 		return err
 	}

--- a/setting/master_status_repository.go
+++ b/setting/master_status_repository.go
@@ -2,8 +2,7 @@ package setting
 
 import (
 	"context"
-
-	"github.com/go-pg/pg/v9"
+	"hpc-express-service/common"
 )
 
 type MasterStatusRepository interface {
@@ -24,54 +23,78 @@ func NewMasterStatusRepository() MasterStatusRepository {
 }
 
 func (r *masterStatusRepository) CreateMasterStatus(ctx context.Context, status *MasterStatus) (*MasterStatus, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
-	_, err := db.ModelContext(ctx, status).Insert()
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	_, err = db.Model(status).Insert()
 	return status, err
 }
 
 func (r *masterStatusRepository) GetAllMasterStatuses(ctx context.Context) ([]MasterStatus, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
 	var statuses []MasterStatus
-	err := db.ModelContext(ctx, &statuses).Select()
+	err = db.Model(&statuses).Select()
 	return statuses, err
 }
 
 func (r *masterStatusRepository) GetMasterStatusesByType(ctx context.Context, statusType string) ([]MasterStatus, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
 	var statuses []MasterStatus
-	err := db.ModelContext(ctx, &statuses).Where("type = ?", statusType).Select()
+	err = db.Model(&statuses).Where("type = ?", statusType).Select()
 	return statuses, err
 }
 
 func (r *masterStatusRepository) GetMasterStatusByUUID(ctx context.Context, uuid string) (*MasterStatus, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
 	status := new(MasterStatus)
-	err := db.ModelContext(ctx, status).Where("uuid = ?", uuid).Select()
+	err = db.Model(status).Where("uuid = ?", uuid).Select()
 	return status, err
 }
 
 func (r *masterStatusRepository) UpdateMasterStatus(ctx context.Context, status *MasterStatus) (*MasterStatus, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
-	_, err := db.ModelContext(ctx, status).WherePK().Update()
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	_, err = db.Model(status).WherePK().Update()
 	return status, err
 }
 
 func (r *masterStatusRepository) DeleteMasterStatus(ctx context.Context, uuid string) error {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
-	_, err := db.ModelContext(ctx, &MasterStatus{}).Where("uuid = ?", uuid).Delete()
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = db.Model(&MasterStatus{}).Where("uuid = ?", uuid).Delete()
 	return err
 }
 
 func (r *masterStatusRepository) GetDefaultStatusByType(ctx context.Context, statusType string) (*MasterStatus, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
 	status := new(MasterStatus)
-	err := db.ModelContext(ctx, status).Where("type = ?", statusType).Where("is_default = ?", true).First()
+	err = db.Model(status).Where("type = ?", statusType).Where("is_default = ?", true).First()
 	return status, err
 }
 
 func (r *masterStatusRepository) GetStatusByNameAndType(ctx context.Context, name, statusType string) (*MasterStatus, error) {
-	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
 	status := new(MasterStatus)
-	err := db.ModelContext(ctx, status).Where("name = ?", name).Where("type = ?", statusType).First()
+	err = db.Model(status).Where("name = ?", name).Where("type = ?", statusType).First()
 	return status, err
 }


### PR DESCRIPTION
Resolves a panic that caused `net::ERR_EMPTY_RESPONSE` errors.

The panic was caused by a type assertion failure in repositories that were not designed to be called from within a database transaction. When a service started a transaction and passed the context containing a `*pg.Tx` to a repository expecting a `*pg.DB`, the application would panic and crash.

This commit introduces a centralized, transaction-aware querier logic in `common/db.go`. The `common.GetQer` function can correctly return either a database connection or a transaction from the context.

The following repositories have been refactored to use this new centralized logic:
- `setting/master_status_repository.go` (the source of the original panic)
- `outbound/cargo_manifest_repository.go`
- `outbound/draft_mawb_repository.go`
- `common/repository.go`

Additionally, this commit fixes a bug in the `UpdateCargoManifest` service where the manifest's status was being incorrectly reset to the default on every update.