### PR TITLE
Add cargo manifest and weight slip detail endpoints

### DIFF
--- a/outbound/cargomanifest/service.go
+++ b/outbound/cargomanifest/service.go
@@ -9,6 +9,7 @@ import (
 
 type CargoManifestService interface {
 	GetCargoManifestByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error)
+	GetCargoManifestByUUID(ctx context.Context, manifestUUID string) (*CargoManifest, error)
 	CreateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
 	UpdateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
 	UpdateCargoManifestStatus(ctx context.Context, mawbUUID, statusUUID string) error
@@ -26,6 +27,11 @@ func NewCargoManifestService(repo CargoManifestRepository, statusSvc setting.Mas
 func (s *cargoManifestService) GetCargoManifestByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error) {
 	// Add any business logic here if needed, e.g., permission checks.
 	return s.repo.GetByMAWBUUID(ctx, mawbUUID)
+}
+
+// GetCargoManifestByUUID retrieves a cargo manifest by its own UUID.
+func (s *cargoManifestService) GetCargoManifestByUUID(ctx context.Context, manifestUUID string) (*CargoManifest, error) {
+	return s.repo.GetByUUID(ctx, manifestUUID)
 }
 
 // setDefaultStatus sets the status of the manifest to the default 'Draft' status.

--- a/outbound/weightSlip/service.go
+++ b/outbound/weightSlip/service.go
@@ -9,6 +9,7 @@ import (
 
 type WeightSlipService interface {
 	GetWeightSlipByMAWBUUID(ctx context.Context, mawbUUID string) (*WeightSlip, error)
+	GetWeightSlipByUUID(ctx context.Context, wsUUID string) (*WeightSlip, error)
 	CreateWeightSlip(ctx context.Context, ws *WeightSlip) (*WeightSlip, error)
 	UpdateWeightSlip(ctx context.Context, ws *WeightSlip) (*WeightSlip, error)
 	UpdateWeightSlipStatus(ctx context.Context, mawbUUID, statusUUID string) error
@@ -25,6 +26,11 @@ func NewWeightSlipService(repo WeightSlipRepository, statusSvc setting.MasterSta
 
 func (s *weightSlipService) GetWeightSlipByMAWBUUID(ctx context.Context, mawbUUID string) (*WeightSlip, error) {
 	return s.repo.GetByMAWBUUID(ctx, mawbUUID)
+}
+
+// GetWeightSlipByUUID retrieves a weight slip by its own UUID.
+func (s *weightSlipService) GetWeightSlipByUUID(ctx context.Context, wsUUID string) (*WeightSlip, error) {
+	return s.repo.GetByUUID(ctx, wsUUID)
 }
 
 func (s *weightSlipService) setDefaultStatus(ctx context.Context, ws *WeightSlip) error {

--- a/server/mawbinfo.go
+++ b/server/mawbinfo.go
@@ -40,6 +40,12 @@ func (h *mawbInfoHandler) router() chi.Router {
 	// Draft MAWB Detail Route by draft UUID (not mawb_info_uuid)
 	r.Get("/draft-mawb/{draft_uuid}", h.getDraftMAWBByUUID)
 
+	// Cargo manifest Detail Route by cargo manifest UUID (not mawb_info_uuid)
+	r.Get("/cargo-manifest/{cargo_manifest_uuid}", h.getCargoManifestByUUID)
+
+	// Weight Slip Detail Route by weight slip UUID (not mawb_info_uuid)
+	r.Get("/weight-slip/{weight_slip_uuid}", h.getWeightSlipByUUID)
+
 	r.Route("/{uuid}", func(r chi.Router) {
 		r.Get("/", h.getMawbInfo)
 		r.Put("/", h.updateMawbInfo)
@@ -106,6 +112,27 @@ func (h *mawbInfoHandler) getCargoManifest(w http.ResponseWriter, r *http.Reques
 	}
 	if manifest == nil {
 		render.Render(w, r, &ErrResponse{HTTPStatusCode: http.StatusNotFound, Message: "Cargo Manifest not found for this MAWB"})
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(manifest, "Success"))
+}
+
+// getCargoManifestByUUID retrieves a cargo manifest using its own UUID instead of the MAWB info UUID.
+func (h *mawbInfoHandler) getCargoManifestByUUID(w http.ResponseWriter, r *http.Request) {
+	manifestUUID := chi.URLParam(r, "cargo_manifest_uuid")
+	if manifestUUID == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("cargo_manifest_uuid parameter is required")))
+		return
+	}
+
+	manifest, err := h.cargoManifestSvc.GetCargoManifestByUUID(r.Context(), manifestUUID)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+	if manifest == nil {
+		render.Render(w, r, &ErrResponse{HTTPStatusCode: http.StatusNotFound, Message: "Cargo Manifest not found"})
 		return
 	}
 
@@ -346,6 +373,27 @@ func (h *mawbInfoHandler) getWeightslip(w http.ResponseWriter, r *http.Request) 
 	}
 	if ws == nil {
 		render.Render(w, r, &ErrResponse{HTTPStatusCode: http.StatusNotFound, Message: "Weight Slip not found for this MAWB"})
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(ws, "Success"))
+}
+
+// getWeightSlipByUUID retrieves a weight slip using its own UUID instead of the MAWB info UUID.
+func (h *mawbInfoHandler) getWeightSlipByUUID(w http.ResponseWriter, r *http.Request) {
+	wsUUID := chi.URLParam(r, "weight_slip_uuid")
+	if wsUUID == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("weight_slip_uuid parameter is required")))
+		return
+	}
+
+	ws, err := h.weightslipSvc.GetWeightSlipByUUID(r.Context(), wsUUID)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+	if ws == nil {
+		render.Render(w, r, &ErrResponse{HTTPStatusCode: http.StatusNotFound, Message: "Weight Slip not found"})
 		return
 	}
 


### PR DESCRIPTION
## Summary
- add top-level routes to fetch cargo manifest and weight slip by their own UUIDs
- implement handlers, service, and repository methods for cargo manifest and weight slip UUID lookups

## Testing
- `go test ./...` *(fails: command terminated without completing)*
- `go build ./...` *(fails: command terminated without completing)*

------
https://chatgpt.com/codex/tasks/task_e_68a8167bdc90832e937d04632368919b