### PR TITLE
Add cargo manifest and weight slip detail endpoints

### DIFF
--- a/outbound/cargomanifest/cargo_manifest.go
+++ b/outbound/cargomanifest/cargo_manifest.go
@@ -40,3 +40,15 @@ type CargoManifestItem struct {
 	ShipperNameAndAddress   string   `json:"shipperNameAndAddress" db:"shipper_name_address"`
 	ConsigneeNameAndAddress string   `json:"consigneeNameAndAddress" db:"consignee_name_address"`
 }
+
+// CargoManifestListItem represents a cargo manifest item in the list view
+// with limited fields for listing endpoints.
+type CargoManifestListItem struct {
+	UUID         string `json:"uuid"`
+	MAWBInfoUUID string `json:"mawbInfoUuid"`
+	MAWBNumber   string `json:"mawbNumber"`
+	CustomerName string `json:"customerName"`
+	CreatedAt    string `json:"createdAt"`
+	Status       string `json:"status"`
+	IsDeleted    bool   `json:"isDeleted"`
+}

--- a/outbound/cargomanifest/service.go
+++ b/outbound/cargomanifest/service.go
@@ -9,9 +9,11 @@ import (
 
 type CargoManifestService interface {
 	GetCargoManifestByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error)
+	GetCargoManifestByUUID(ctx context.Context, manifestUUID string) (*CargoManifest, error)
 	CreateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
 	UpdateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
 	UpdateCargoManifestStatus(ctx context.Context, mawbUUID, statusUUID string) error
+	GetAllCargoManifest(ctx context.Context, startDate, endDate string) ([]CargoManifestListItem, error)
 }
 
 type cargoManifestService struct {
@@ -26,6 +28,15 @@ func NewCargoManifestService(repo CargoManifestRepository, statusSvc setting.Mas
 func (s *cargoManifestService) GetCargoManifestByMAWBUUID(ctx context.Context, mawbUUID string) (*CargoManifest, error) {
 	// Add any business logic here if needed, e.g., permission checks.
 	return s.repo.GetByMAWBUUID(ctx, mawbUUID)
+}
+
+// GetCargoManifestByUUID retrieves a cargo manifest by its own UUID.
+func (s *cargoManifestService) GetCargoManifestByUUID(ctx context.Context, manifestUUID string) (*CargoManifest, error) {
+	return s.repo.GetByUUID(ctx, manifestUUID)
+}
+
+func (s *cargoManifestService) GetAllCargoManifest(ctx context.Context, startDate, endDate string) ([]CargoManifestListItem, error) {
+	return s.repo.GetAll(ctx, startDate, endDate)
 }
 
 // setDefaultStatus sets the status of the manifest to the default 'Draft' status.

--- a/outbound/weightSlip/repository.go
+++ b/outbound/weightSlip/repository.go
@@ -3,6 +3,7 @@ package outbound
 import (
 	"context"
 	"hpc-express-service/common"
+	"strings"
 	"time"
 
 	"github.com/go-pg/pg/v9"
@@ -11,8 +12,10 @@ import (
 
 type WeightSlipRepository interface {
 	GetByMAWBUUID(ctx context.Context, mawbUUID string) (*WeightSlip, error)
+	GetByUUID(ctx context.Context, uuid string) (*WeightSlip, error)
 	Create(ctx context.Context, ws *WeightSlip) (*WeightSlip, error)
 	Update(ctx context.Context, ws *WeightSlip) (*WeightSlip, error)
+	GetAll(ctx context.Context, startDate, endDate string) ([]WeightSlipListItem, error)
 }
 
 type weightSlipRepository struct{}
@@ -49,6 +52,37 @@ func (r *weightSlipRepository) GetByMAWBUUID(ctx context.Context, mawbUUID strin
 	}
 
 	// map nested structs
+	ws.AfterSelect(nil)
+
+	return ws, nil
+}
+
+func (r *weightSlipRepository) GetByUUID(ctx context.Context, uuid string) (*WeightSlip, error) {
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ws := &WeightSlip{}
+	err = db.Model(ws).
+		Column("weight_slip.*").
+		ColumnExpr("ms.name AS status").
+		Join("LEFT JOIN master_status AS ms ON ms.uuid = weight_slip.status_uuid").
+		Where("weight_slip.uuid = ?", uuid).
+		Select()
+	if err != nil {
+		if err == pg.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if err := db.Model(&ws.Dimensions).
+		Where("weightslip_uuid = ?", ws.UUID).
+		Select(); err != nil {
+		return nil, err
+	}
+
 	ws.AfterSelect(nil)
 
 	return ws, nil
@@ -110,4 +144,56 @@ func (r *weightSlipRepository) Update(ctx context.Context, ws *WeightSlip) (*Wei
 	}
 
 	return r.GetByMAWBUUID(ctx, ws.MAWBInfoUUID)
+}
+
+// GetAll retrieves all weight slip records with optional date filtering and customer information.
+func (r *weightSlipRepository) GetAll(ctx context.Context, startDate, endDate string) ([]WeightSlipListItem, error) {
+	db, err := common.GetQer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var items []WeightSlipListItem
+
+	baseQuery := `
+            SELECT
+                    ws.uuid::text,
+                    ws.mawb_info_uuid::text,
+                    COALESCE(ws.slip_no, '') as slip_no,
+                    COALESCE(ws.mawb, '') as mawb,
+                    COALESCE(ws.hawb, '') as hawb,
+                    COALESCE(c.name, '') as customer_name,
+                    TO_CHAR(ws.created_at AT TIME ZONE 'Asia/Bangkok', 'DD-MM-YYYY HH24:MI:SS') as created_at,
+                    COALESCE(ms.name, 'Draft') as status,
+                    CASE WHEN ms.name = 'Cancelled' THEN true ELSE false END as is_deleted
+            FROM public.weight_slip ws
+            LEFT JOIN public.tbl_mawb_info mi ON ws.mawb_info_uuid::text = mi.uuid::text
+            LEFT JOIN public.tbl_customers c ON mi.customer_uuid::text = c.uuid::text
+            LEFT JOIN public.master_status ms ON ws.status_uuid = ms.uuid
+    `
+
+	var whereConditions []string
+	var args []interface{}
+
+	if startDate != "" {
+		whereConditions = append(whereConditions, "DATE(ws.created_at AT TIME ZONE 'Asia/Bangkok') >= ?")
+		args = append(args, startDate)
+	}
+	if endDate != "" {
+		whereConditions = append(whereConditions, "DATE(ws.created_at AT TIME ZONE 'Asia/Bangkok') <= ?")
+		args = append(args, endDate)
+	}
+
+	query := baseQuery
+	if len(whereConditions) > 0 {
+		query += " WHERE " + strings.Join(whereConditions, " AND ")
+	}
+	query += " ORDER BY ws.created_at DESC"
+
+	_, err = db.Query(&items, query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return items, nil
 }

--- a/outbound/weightSlip/service.go
+++ b/outbound/weightSlip/service.go
@@ -9,9 +9,11 @@ import (
 
 type WeightSlipService interface {
 	GetWeightSlipByMAWBUUID(ctx context.Context, mawbUUID string) (*WeightSlip, error)
+	GetWeightSlipByUUID(ctx context.Context, wsUUID string) (*WeightSlip, error)
 	CreateWeightSlip(ctx context.Context, ws *WeightSlip) (*WeightSlip, error)
 	UpdateWeightSlip(ctx context.Context, ws *WeightSlip) (*WeightSlip, error)
 	UpdateWeightSlipStatus(ctx context.Context, mawbUUID, statusUUID string) error
+	GetAllWeightSlip(ctx context.Context, startDate, endDate string) ([]WeightSlipListItem, error)
 }
 
 type weightSlipService struct {
@@ -25,6 +27,11 @@ func NewWeightSlipService(repo WeightSlipRepository, statusSvc setting.MasterSta
 
 func (s *weightSlipService) GetWeightSlipByMAWBUUID(ctx context.Context, mawbUUID string) (*WeightSlip, error) {
 	return s.repo.GetByMAWBUUID(ctx, mawbUUID)
+}
+
+// GetWeightSlipByUUID retrieves a weight slip by its own UUID.
+func (s *weightSlipService) GetWeightSlipByUUID(ctx context.Context, wsUUID string) (*WeightSlip, error) {
+	return s.repo.GetByUUID(ctx, wsUUID)
 }
 
 func (s *weightSlipService) setDefaultStatus(ctx context.Context, ws *WeightSlip) error {
@@ -122,4 +129,8 @@ func (s *weightSlipService) UpdateWeightSlipStatus(ctx context.Context, mawbUUID
 	}
 
 	return tx.Commit()
+}
+
+func (s *weightSlipService) GetAllWeightSlip(ctx context.Context, startDate, endDate string) ([]WeightSlipListItem, error) {
+	return s.repo.GetAll(ctx, startDate, endDate)
 }

--- a/outbound/weightSlip/weightslip.go
+++ b/outbound/weightSlip/weightslip.go
@@ -77,3 +77,16 @@ func (w *WeightSlip) AfterSelect(ctx interface{}) error {
 	w.Weights = Weights{GW: w.GW, TW: w.TW, NW: w.NW, DimWeight: w.DimWeight, VolumeM3: w.VolumeM3}
 	return nil
 }
+
+// WeightSlipListItem represents a weight slip item for listing endpoints with limited fields.
+type WeightSlipListItem struct {
+	UUID         string `json:"uuid"`
+	MAWBInfoUUID string `json:"mawbInfoUuid"`
+	SlipNo       string `json:"slipNo"`
+	MAWB         string `json:"mawb"`
+	HAWB         string `json:"hawb"`
+	CustomerName string `json:"customerName"`
+	CreatedAt    string `json:"createdAt"`
+	Status       string `json:"status"`
+	IsDeleted    bool   `json:"isDeleted"`
+}

--- a/server/mawbinfo.go
+++ b/server/mawbinfo.go
@@ -40,6 +40,18 @@ func (h *mawbInfoHandler) router() chi.Router {
 	// Draft MAWB Detail Route by draft UUID (not mawb_info_uuid)
 	r.Get("/draft-mawb/{draft_uuid}", h.getDraftMAWBByUUID)
 
+	// Cargo manifest List Route (without uuid parameter)
+	r.Get("/cargo-manifest", h.getAllCargoManifest)
+
+	// Cargo manifest Detail Route by cargo manifest UUID (not mawb_info_uuid)
+	r.Get("/cargo-manifest/{cargo_manifest_uuid}", h.getCargoManifestByUUID)
+
+	// Weight Slip List Route (without uuid parameter)
+	r.Get("/weight-slip", h.getAllWeightSlip)
+
+	// Weight Slip Detail Route by weight slip UUID (not mawb_info_uuid)
+	r.Get("/weight-slip/{weight_slip_uuid}", h.getWeightSlipByUUID)
+
 	r.Route("/{uuid}", func(r chi.Router) {
 		r.Get("/", h.getMawbInfo)
 		r.Put("/", h.updateMawbInfo)
@@ -106,6 +118,27 @@ func (h *mawbInfoHandler) getCargoManifest(w http.ResponseWriter, r *http.Reques
 	}
 	if manifest == nil {
 		render.Render(w, r, &ErrResponse{HTTPStatusCode: http.StatusNotFound, Message: "Cargo Manifest not found for this MAWB"})
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(manifest, "Success"))
+}
+
+// getCargoManifestByUUID retrieves a cargo manifest using its own UUID instead of the MAWB info UUID.
+func (h *mawbInfoHandler) getCargoManifestByUUID(w http.ResponseWriter, r *http.Request) {
+	manifestUUID := chi.URLParam(r, "cargo_manifest_uuid")
+	if manifestUUID == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("cargo_manifest_uuid parameter is required")))
+		return
+	}
+
+	manifest, err := h.cargoManifestSvc.GetCargoManifestByUUID(r.Context(), manifestUUID)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+	if manifest == nil {
+		render.Render(w, r, &ErrResponse{HTTPStatusCode: http.StatusNotFound, Message: "Cargo Manifest not found"})
 		return
 	}
 
@@ -346,6 +379,27 @@ func (h *mawbInfoHandler) getWeightslip(w http.ResponseWriter, r *http.Request) 
 	}
 	if ws == nil {
 		render.Render(w, r, &ErrResponse{HTTPStatusCode: http.StatusNotFound, Message: "Weight Slip not found for this MAWB"})
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(ws, "Success"))
+}
+
+// getWeightSlipByUUID retrieves a weight slip using its own UUID instead of the MAWB info UUID.
+func (h *mawbInfoHandler) getWeightSlipByUUID(w http.ResponseWriter, r *http.Request) {
+	wsUUID := chi.URLParam(r, "weight_slip_uuid")
+	if wsUUID == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("weight_slip_uuid parameter is required")))
+		return
+	}
+
+	ws, err := h.weightslipSvc.GetWeightSlipByUUID(r.Context(), wsUUID)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+	if ws == nil {
+		render.Render(w, r, &ErrResponse{HTTPStatusCode: http.StatusNotFound, Message: "Weight Slip not found"})
 		return
 	}
 
@@ -821,6 +875,32 @@ func (h *mawbInfoHandler) printDraftMAWB(w http.ResponseWriter, r *http.Request)
 	// Write PDF to response
 	w.WriteHeader(http.StatusOK)
 	w.Write(pdfBuffer.Bytes())
+}
+
+func (h *mawbInfoHandler) getAllCargoManifest(w http.ResponseWriter, r *http.Request) {
+	startDate := r.URL.Query().Get("start")
+	endDate := r.URL.Query().Get("end")
+
+	manifests, err := h.cargoManifestSvc.GetAllCargoManifest(r.Context(), startDate, endDate)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(manifests, "Success"))
+}
+
+func (h *mawbInfoHandler) getAllWeightSlip(w http.ResponseWriter, r *http.Request) {
+	startDate := r.URL.Query().Get("start")
+	endDate := r.URL.Query().Get("end")
+
+	slips, err := h.weightslipSvc.GetAllWeightSlip(r.Context(), startDate, endDate)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(slips, "Success"))
 }
 
 func (h *mawbInfoHandler) getAllDraftMAWB(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- add list routes for cargo manifests and weight slips alongside existing detail endpoints
- implement handlers plus service and repository methods to fetch all cargo manifests and weight slips

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a8167bdc90832e937d04632368919b