### PR TITLE
Add list endpoints for cargo manifests and weight slips

### DIFF
--- a/outbound/cargomanifest/cargo_manifest.go
+++ b/outbound/cargomanifest/cargo_manifest.go
@@ -40,3 +40,15 @@ type CargoManifestItem struct {
 	ShipperNameAndAddress   string   `json:"shipperNameAndAddress" db:"shipper_name_address"`
 	ConsigneeNameAndAddress string   `json:"consigneeNameAndAddress" db:"consignee_name_address"`
 }
+
+// CargoManifestListItem represents a cargo manifest item in the list view
+type CargoManifestListItem struct {
+	UUID         string `json:"uuid"`
+	MAWBInfoUUID string `json:"mawbInfoUuid"`
+	MAWBNumber   string `json:"mawbNumber"`
+	FlightNo     string `json:"flightNo"`
+	Shipper      string `json:"shipper"`
+	Consignee    string `json:"consignee"`
+	CreatedAt    string `json:"createdAt"`
+	Status       string `json:"status"`
+}

--- a/outbound/cargomanifest/service.go
+++ b/outbound/cargomanifest/service.go
@@ -13,6 +13,7 @@ type CargoManifestService interface {
 	CreateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
 	UpdateCargoManifest(ctx context.Context, manifest *CargoManifest) (*CargoManifest, error)
 	UpdateCargoManifestStatus(ctx context.Context, mawbUUID, statusUUID string) error
+	GetAllCargoManifest(ctx context.Context, startDate, endDate string) ([]CargoManifestListItem, error)
 }
 
 type cargoManifestService struct {
@@ -135,4 +136,8 @@ func (s *cargoManifestService) UpdateCargoManifestStatus(ctx context.Context, ma
 	}
 
 	return tx.Commit()
+}
+
+func (s *cargoManifestService) GetAllCargoManifest(ctx context.Context, startDate, endDate string) ([]CargoManifestListItem, error) {
+	return s.repo.GetAll(ctx, startDate, endDate)
 }

--- a/outbound/weightSlip/service.go
+++ b/outbound/weightSlip/service.go
@@ -13,6 +13,7 @@ type WeightSlipService interface {
 	CreateWeightSlip(ctx context.Context, ws *WeightSlip) (*WeightSlip, error)
 	UpdateWeightSlip(ctx context.Context, ws *WeightSlip) (*WeightSlip, error)
 	UpdateWeightSlipStatus(ctx context.Context, mawbUUID, statusUUID string) error
+	GetAllWeightSlip(ctx context.Context, startDate, endDate string) ([]WeightSlipListItem, error)
 }
 
 type weightSlipService struct {
@@ -128,4 +129,8 @@ func (s *weightSlipService) UpdateWeightSlipStatus(ctx context.Context, mawbUUID
 	}
 
 	return tx.Commit()
+}
+
+func (s *weightSlipService) GetAllWeightSlip(ctx context.Context, startDate, endDate string) ([]WeightSlipListItem, error) {
+	return s.repo.GetAll(ctx, startDate, endDate)
 }

--- a/outbound/weightSlip/weightslip.go
+++ b/outbound/weightSlip/weightslip.go
@@ -61,6 +61,17 @@ type WeightSlipDimension struct {
 	PCS            int      `json:"pcs" pg:"pcs"`
 }
 
+// WeightSlipListItem represents a weight slip item in the list view
+type WeightSlipListItem struct {
+	UUID         string `json:"uuid"`
+	MAWBInfoUUID string `json:"mawbInfoUuid"`
+	SlipNo       string `json:"slipNo"`
+	MAWB         string `json:"mawb"`
+	HAWB         string `json:"hawb"`
+	CreatedAt    string `json:"createdAt"`
+	Status       string `json:"status"`
+}
+
 func (w *WeightSlip) Bind(r *http.Request) error {
 	w.AgentCode = w.Agent.Code
 	w.AgentName = w.Agent.Name

--- a/server/mawbinfo.go
+++ b/server/mawbinfo.go
@@ -37,6 +37,12 @@ func (h *mawbInfoHandler) router() chi.Router {
 	// Draft MAWB List Route (without uuid parameter)
 	r.Get("/draft-mawb", h.getAllDraftMAWB)
 
+	// Cargo manifest List Route (without uuid parameter)
+	r.Get("/cargo-manifest", h.getAllCargoManifest)
+
+	// Weight Slip List Route (without uuid parameter)
+	r.Get("/weight-slip", h.getAllWeightSlip)
+
 	// Draft MAWB Detail Route by draft UUID (not mawb_info_uuid)
 	r.Get("/draft-mawb/{draft_uuid}", h.getDraftMAWBByUUID)
 
@@ -357,6 +363,19 @@ func (h *mawbInfoHandler) previewCargoManifest(w http.ResponseWriter, r *http.Re
 	w.Write(pdfBuffer.Bytes())
 }
 
+func (h *mawbInfoHandler) getAllCargoManifest(w http.ResponseWriter, r *http.Request) {
+	startDate := r.URL.Query().Get("start")
+	endDate := r.URL.Query().Get("end")
+
+	manifests, err := h.cargoManifestSvc.GetAllCargoManifest(r.Context(), startDate, endDate)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(manifests, "Success"))
+}
+
 // Weight Slip Handlers
 
 func (h *mawbInfoHandler) getWeightslip(w http.ResponseWriter, r *http.Request) {
@@ -614,6 +633,19 @@ func (h *mawbInfoHandler) previewWeightslip(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Disposition", "inline; filename=weight_slip_preview.pdf")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", pdfBuffer.Len()))
 	w.Write(pdfBuffer.Bytes())
+}
+
+func (h *mawbInfoHandler) getAllWeightSlip(w http.ResponseWriter, r *http.Request) {
+	startDate := r.URL.Query().Get("start")
+	endDate := r.URL.Query().Get("end")
+
+	slips, err := h.weightslipSvc.GetAllWeightSlip(r.Context(), startDate, endDate)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(slips, "Success"))
 }
 
 // Draft MAWB Handlers


### PR DESCRIPTION
## Summary
- expose list routes for cargo manifests and weight slips without UUID requirements
- implement service and repository support for querying cargo manifest and weight slip records

## Testing
- `go vet ./outbound/cargomanifest...`
- `go vet ./outbound/weightSlip...`
- `go test ./...` *(fails: no output, command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a81fae3184832e9b2563e2241458d6