### PR TITLE
Include additional fields in weight slip and cargo manifest lists

### DIFF
--- a/outbound/cargomanifest/cargo_manifest.go
+++ b/outbound/cargomanifest/cargo_manifest.go
@@ -47,8 +47,10 @@ type CargoManifestListItem struct {
 	MAWBInfoUUID string `json:"mawbInfoUuid"`
 	MAWBNumber   string `json:"mawbNumber"`
 	FlightNo     string `json:"flightNo"`
+	FreightDate  string `json:"freightDate"`
 	Shipper      string `json:"shipper"`
 	Consignee    string `json:"consignee"`
+	TotalCtn     int    `json:"totalCtn"`
 	CreatedAt    string `json:"createdAt"`
 	Status       string `json:"status"`
 }

--- a/outbound/cargomanifest/repository.go
+++ b/outbound/cargomanifest/repository.go
@@ -163,8 +163,10 @@ func (r *cargoManifestRepository) GetAll(ctx context.Context, startDate, endDate
                        cm.mawb_info_uuid::text,
                        COALESCE(cm.mawb_number, '') AS mawb_number,
                        COALESCE(cm.flight_no, '') AS flight_no,
+                       COALESCE(TO_CHAR(cm.freight_date, 'DD-MM-YYYY'), '') AS freight_date,
                        COALESCE(cm.shipper, '') AS shipper,
                        COALESCE(cm.consignee, '') AS consignee,
+                       COALESCE(cm.total_ctn::int, 0) AS total_ctn,
                        TO_CHAR(cm.created_at AT TIME ZONE 'Asia/Bangkok', 'DD-MM-YYYY HH24:MI:SS') AS created_at,
                        COALESCE(ms.name, 'Draft') AS status
                FROM public.cargo_manifest cm

--- a/outbound/weightSlip/repository.go
+++ b/outbound/weightSlip/repository.go
@@ -161,6 +161,10 @@ func (r *weightSlipRepository) GetAll(ctx context.Context, startDate, endDate st
                        COALESCE(ws.slip_no, '') AS slip_no,
                        COALESCE(ws.mawb, '') AS mawb,
                        COALESCE(ws.hawb, '') AS hawb,
+                       COALESCE(ws.dest, '') AS dest,
+                       COALESCE(ws.flight, '') AS flight,
+                       COALESCE(ws.agent_name, '') AS agent_name,
+                       CASE WHEN ws.gw IS NULL THEN '' ELSE CONCAT(TRIM(to_char(ws.gw, 'FM999999990.##')), ' KGS') END AS gross_weight,
                        TO_CHAR(ws.created_at AT TIME ZONE 'Asia/Bangkok', 'DD-MM-YYYY HH24:MI:SS') AS created_at,
                        COALESCE(ms.name, 'Draft') AS status
                FROM public.weight_slip ws

--- a/outbound/weightSlip/weightslip.go
+++ b/outbound/weightSlip/weightslip.go
@@ -68,6 +68,10 @@ type WeightSlipListItem struct {
 	SlipNo       string `json:"slipNo"`
 	MAWB         string `json:"mawb"`
 	HAWB         string `json:"hawb"`
+	Dest         string `json:"dest"`
+	Flight       string `json:"flight"`
+	AgentName    string `json:"agentName"`
+	GrossWeight  string `json:"grossWeight"`
 	CreatedAt    string `json:"createdAt"`
 	Status       string `json:"status"`
 }


### PR DESCRIPTION
## Summary
- expose destination, flight, agent name, and gross weight in weight slip list response
- expose freight date and total carton count in cargo manifest list response

## Testing
- `go test ./...` *(fails: command hung due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a82cf2d92c832e88c635b562436feb