### PR TITLE
Relocate sea waybill details module to inbound

### DIFF
--- a/factory/repository.go
+++ b/factory/repository.go
@@ -7,6 +7,7 @@ import (
 	"hpc-express-service/dashboard"
 	"hpc-express-service/dropdown"
 	inbound "hpc-express-service/inbound/express"
+	"hpc-express-service/inbound/seawaybilldetails"
 	"hpc-express-service/mawb"
 	cargoManifest "hpc-express-service/outbound/cargomanifest"
 	draftMawb "hpc-express-service/outbound/draftmawb"
@@ -35,6 +36,7 @@ type RepositoryFactory struct {
 	ShopeeRepo                    shopee.Repository
 	MawbRepo                      mawb.Repository
 	MawbInfoRepo                  mawbinfo.Repository
+	SeaWaybillDetailsRepo         seawaybilldetails.Repository
 	CustomerRepo                  customer.Repository
 	DashboardRepo                 dashboard.Repository
 	UserRepo                      user.Repository
@@ -59,6 +61,7 @@ func NewRepositoryFactory() *RepositoryFactory {
 		ShopeeRepo:                    shopee.NewRepository(timeoutContext),
 		MawbRepo:                      mawb.NewRepository(timeoutContext),
 		MawbInfoRepo:                  mawbinfo.NewRepository(timeoutContext),
+		SeaWaybillDetailsRepo:         seawaybilldetails.NewRepository(timeoutContext),
 		CustomerRepo:                  customer.NewRepository(timeoutContext),
 		DashboardRepo:                 dashboard.NewRepository(timeoutContext),
 		UserRepo:                      user.NewRepository(timeoutContext),

--- a/factory/service.go
+++ b/factory/service.go
@@ -11,6 +11,7 @@ import (
 	"hpc-express-service/dropdown"
 	"hpc-express-service/gcs"
 	inbound "hpc-express-service/inbound/express"
+	"hpc-express-service/inbound/seawaybilldetails"
 	"hpc-express-service/mawb"
 	cargoManifest "hpc-express-service/outbound/cargomanifest"
 	draftMawb "hpc-express-service/outbound/draftmawb"
@@ -38,6 +39,7 @@ type ServiceFactory struct {
 	ShopeeSvc                 shopee.Service
 	MawbSvc                   mawb.Service
 	MawbInfoSvc               mawbinfo.Service
+	SeaWaybillDetailsSvc      seawaybilldetails.Service
 	CustomerSvc               customer.Service
 	DashboardSvc              dashboard.Service
 	UserSvc                   user.Service
@@ -106,6 +108,14 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 	// MawbInfo
 	mawbInfoSvc := mawbinfo.NewService(
 		repo.MawbInfoRepo,
+		timeoutContext,
+		gcsClient,
+		conf,
+	)
+
+	// Sea Waybill Details
+	seaWaybillDetailsSvc := seawaybilldetails.NewService(
+		repo.SeaWaybillDetailsRepo,
 		timeoutContext,
 		gcsClient,
 		conf,
@@ -182,6 +192,7 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 		ShopeeSvc:                 shopeeSvc,
 		MawbSvc:                   mawbSvc,
 		MawbInfoSvc:               mawbInfoSvc,
+		SeaWaybillDetailsSvc:      seaWaybillDetailsSvc,
 		CustomerSvc:               customerSvc,
 		DashboardSvc:              dashboardSvc,
 		UserSvc:                   userSvc,

--- a/inbound/seawaybilldetails/model.go
+++ b/inbound/seawaybilldetails/model.go
@@ -1,0 +1,47 @@
+package seawaybilldetails
+
+import (
+	"mime/multipart"
+	"net/http"
+)
+
+// AttachmentInfo represents metadata for a stored attachment file.
+type AttachmentInfo struct {
+	FileName string `json:"fileName"`
+	FileURL  string `json:"fileUrl"`
+	FileSize int64  `json:"fileSize"`
+}
+
+// SeaWaybillDetails captures the persisted details and attachments for a sea waybill record.
+type SeaWaybillDetails struct {
+	UUID         string           `json:"uuid"`
+	GrossWeight  float64          `json:"grossWeight"`
+	VolumeWeight float64          `json:"volumeWeight"`
+	DutyTax      float64          `json:"dutyTax"`
+	Attachments  []AttachmentInfo `json:"attachments,omitempty"`
+	CreatedAt    string           `json:"createdAt"`
+	UpdatedAt    string           `json:"updatedAt"`
+}
+
+// UpsertSeaWaybillDetailsRequest represents the multipart form payload for creating or updating a record.
+type UpsertSeaWaybillDetailsRequest struct {
+	GrossWeight  string                  `form:"grossWeight" validate:"required"`
+	VolumeWeight string                  `form:"volumeWeight" validate:"required"`
+	DutyTax      string                  `form:"dutyTax" validate:"required"`
+	Attachments  []*multipart.FileHeader `form:"attachments"`
+}
+
+// Bind satisfies the render.Binder interface.
+func (r *UpsertSeaWaybillDetailsRequest) Bind(req *http.Request) error {
+	return nil
+}
+
+// DeleteAttachmentRequest represents the body for deleting a specific attachment.
+type DeleteAttachmentRequest struct {
+	FileName string `json:"fileName" validate:"required"`
+}
+
+// Bind satisfies the render.Binder interface.
+func (r *DeleteAttachmentRequest) Bind(req *http.Request) error {
+	return nil
+}

--- a/inbound/seawaybilldetails/repository.go
+++ b/inbound/seawaybilldetails/repository.go
@@ -1,0 +1,382 @@
+package seawaybilldetails
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-pg/pg/v9"
+
+	"hpc-express-service/utils"
+)
+
+type Repository interface {
+	CreateSeaWaybillDetails(ctx context.Context, data *seaWaybillDetailsRecord, attachments []AttachmentInfo) (*SeaWaybillDetails, error)
+	GetSeaWaybillDetails(ctx context.Context, uuid string) (*SeaWaybillDetails, error)
+	UpdateSeaWaybillDetails(ctx context.Context, uuid string, data *seaWaybillDetailsRecord, attachments []AttachmentInfo) (*SeaWaybillDetails, error)
+	DeleteSeaWaybillAttachment(ctx context.Context, uuid, fileName string) (string, error)
+}
+
+type repository struct {
+	contextTimeout time.Duration
+}
+
+type seaWaybillDetailsRecord struct {
+	UUID         string
+	GrossWeight  string
+	VolumeWeight string
+	DutyTax      string
+}
+
+func NewRepository(timeout time.Duration) Repository {
+	return &repository{contextTimeout: timeout}
+}
+
+func (r repository) ensureTable(ctx context.Context, db *pg.DB) error {
+	sqlStr := `
+        CREATE TABLE IF NOT EXISTS tbl_sea_waybill_details (
+            id SERIAL PRIMARY KEY,
+            uuid UUID NOT NULL UNIQUE,
+            gross_weight NUMERIC(10,2) NOT NULL,
+            volume_weight NUMERIC(10,2) NOT NULL,
+            duty_tax NUMERIC(10,2) NOT NULL,
+            attachments JSONB,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    `
+	if _, err := db.ExecContext(ctx, sqlStr); err != nil {
+		return err
+	}
+
+	alterSQL := `
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'tbl_sea_waybill_details'
+                AND column_name = 'attachments'
+            ) THEN
+                ALTER TABLE tbl_sea_waybill_details ADD COLUMN attachments JSONB;
+            END IF;
+        END $$;
+    `
+	if _, err := db.ExecContext(ctx, alterSQL); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r repository) CreateSeaWaybillDetails(ctx context.Context, data *seaWaybillDetailsRecord, attachments []AttachmentInfo) (*SeaWaybillDetails, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.ensureTable(ctx, db); err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	attachmentsJSON := "[]"
+	if len(attachments) > 0 {
+		bytes, err := json.Marshal(attachments)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal attachments: %v", err)
+		}
+		attachmentsJSON = string(bytes)
+	}
+
+	sqlStr := `
+        INSERT INTO tbl_sea_waybill_details
+            (uuid, gross_weight, volume_weight, duty_tax, attachments)
+        VALUES
+            (?, ?, ?, ?, ?::jsonb)
+        RETURNING
+            uuid,
+            gross_weight,
+            volume_weight,
+            duty_tax,
+            COALESCE(attachments::text, '[]') as attachments,
+            to_char(created_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as created_at,
+            to_char(updated_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at
+    `
+	sqlStr = utils.ReplaceSQL(sqlStr, "?")
+
+	stmt, err := db.Prepare(sqlStr)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+	defer stmt.Close()
+
+	var (
+		response       SeaWaybillDetails
+		attachmentsStr string
+	)
+	_, err = stmt.QueryOneContext(ctx, pg.Scan(
+		&response.UUID,
+		&response.GrossWeight,
+		&response.VolumeWeight,
+		&response.DutyTax,
+		&attachmentsStr,
+		&response.CreatedAt,
+		&response.UpdatedAt,
+	),
+		data.UUID,
+		data.GrossWeight,
+		data.VolumeWeight,
+		data.DutyTax,
+		attachmentsJSON,
+	)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	if attachmentsStr != "" && attachmentsStr != "[]" {
+		if err := json.Unmarshal([]byte(attachmentsStr), &response.Attachments); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal attachments: %v", err)
+		}
+	}
+
+	return &response, nil
+}
+
+func (r repository) GetSeaWaybillDetails(ctx context.Context, uuid string) (*SeaWaybillDetails, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.ensureTable(ctx, db); err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	sqlStr := `
+        SELECT
+            uuid,
+            gross_weight,
+            volume_weight,
+            duty_tax,
+            COALESCE(attachments::text, '[]') as attachments,
+            to_char(created_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as created_at,
+            to_char(updated_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at
+        FROM tbl_sea_waybill_details
+        WHERE uuid = ?
+    `
+	sqlStr = utils.ReplaceSQL(sqlStr, "?")
+
+	stmt, err := db.Prepare(sqlStr)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+	defer stmt.Close()
+
+	var (
+		response       SeaWaybillDetails
+		attachmentsStr string
+	)
+	_, err = stmt.QueryOneContext(ctx, pg.Scan(
+		&response.UUID,
+		&response.GrossWeight,
+		&response.VolumeWeight,
+		&response.DutyTax,
+		&attachmentsStr,
+		&response.CreatedAt,
+		&response.UpdatedAt,
+	), uuid)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	if attachmentsStr != "" && attachmentsStr != "[]" {
+		if err := json.Unmarshal([]byte(attachmentsStr), &response.Attachments); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal attachments: %v", err)
+		}
+	}
+
+	return &response, nil
+}
+
+func (r repository) UpdateSeaWaybillDetails(ctx context.Context, uuid string, data *seaWaybillDetailsRecord, attachments []AttachmentInfo) (*SeaWaybillDetails, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.ensureTable(ctx, db); err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	var existingAttachmentsStr string
+	_, err := db.QueryOneContext(ctx, pg.Scan(&existingAttachmentsStr), utils.ReplaceSQL(`
+        SELECT COALESCE(attachments::text, '[]')
+        FROM tbl_sea_waybill_details
+        WHERE uuid = ?
+    `, "?"), uuid)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	var existingAttachments []AttachmentInfo
+	if existingAttachmentsStr != "" && existingAttachmentsStr != "[]" {
+		if err := json.Unmarshal([]byte(existingAttachmentsStr), &existingAttachments); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal existing attachments: %v", err)
+		}
+	}
+
+	allAttachments := existingAttachments
+	if len(attachments) > 0 {
+		allAttachments = append(allAttachments, attachments...)
+	}
+
+	attachmentsJSON := "[]"
+	if len(allAttachments) > 0 {
+		bytes, err := json.Marshal(allAttachments)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal attachments: %v", err)
+		}
+		attachmentsJSON = string(bytes)
+	}
+
+	sqlStr := `
+        UPDATE tbl_sea_waybill_details
+        SET
+            gross_weight = ?,
+            volume_weight = ?,
+            duty_tax = ?,
+            attachments = ?::jsonb,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE uuid = ?
+        RETURNING
+            uuid,
+            gross_weight,
+            volume_weight,
+            duty_tax,
+            COALESCE(attachments::text, '[]') as attachments,
+            to_char(created_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as created_at,
+            to_char(updated_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at
+    `
+	sqlStr = utils.ReplaceSQL(sqlStr, "?")
+
+	stmt, err := db.Prepare(sqlStr)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+	defer stmt.Close()
+
+	var (
+		response       SeaWaybillDetails
+		attachmentsStr string
+	)
+	_, err = stmt.QueryOneContext(ctx, pg.Scan(
+		&response.UUID,
+		&response.GrossWeight,
+		&response.VolumeWeight,
+		&response.DutyTax,
+		&attachmentsStr,
+		&response.CreatedAt,
+		&response.UpdatedAt,
+	),
+		data.GrossWeight,
+		data.VolumeWeight,
+		data.DutyTax,
+		attachmentsJSON,
+		uuid,
+	)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	if attachmentsStr != "" && attachmentsStr != "[]" {
+		if err := json.Unmarshal([]byte(attachmentsStr), &response.Attachments); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal attachments: %v", err)
+		}
+	}
+
+	return &response, nil
+}
+
+func (r repository) DeleteSeaWaybillAttachment(ctx context.Context, uuid, fileName string) (string, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return "", utils.PostgresErrorTransform(err)
+	}
+	defer tx.Rollback()
+
+	var attachmentsStr string
+	_, err = tx.QueryOneContext(ctx, pg.Scan(&attachmentsStr), utils.ReplaceSQL(`
+        SELECT COALESCE(attachments::text, '[]')
+        FROM tbl_sea_waybill_details
+        WHERE uuid = ?
+        FOR UPDATE
+    `, "?"), uuid)
+	if err != nil {
+		tx.Rollback()
+		return "", utils.PostgresErrorTransform(err)
+	}
+
+	var attachments []AttachmentInfo
+	if attachmentsStr != "" && attachmentsStr != "[]" {
+		if err := json.Unmarshal([]byte(attachmentsStr), &attachments); err != nil {
+			tx.Rollback()
+			return "", fmt.Errorf("failed to unmarshal attachments: %v", err)
+		}
+	}
+
+	var (
+		updatedAttachments []AttachmentInfo
+		removedFileURL     string
+		found              bool
+	)
+
+	for _, attachment := range attachments {
+		if attachment.FileName == fileName {
+			removedFileURL = attachment.FileURL
+			found = true
+			continue
+		}
+		updatedAttachments = append(updatedAttachments, attachment)
+	}
+
+	if !found {
+		tx.Rollback()
+		return "", utils.ErrRecordNotFound
+	}
+
+	attachmentsJSON := "[]"
+	if len(updatedAttachments) > 0 {
+		bytes, err := json.Marshal(updatedAttachments)
+		if err != nil {
+			tx.Rollback()
+			return "", fmt.Errorf("failed to marshal updated attachments: %v", err)
+		}
+		attachmentsJSON = string(bytes)
+	}
+
+	stmt, err := tx.Prepare(utils.ReplaceSQL(`
+        UPDATE tbl_sea_waybill_details
+        SET attachments = ?::jsonb, updated_at = CURRENT_TIMESTAMP
+        WHERE uuid = ?
+    `, "?"))
+	if err != nil {
+		return "", utils.PostgresErrorTransform(err)
+	}
+	defer stmt.Close()
+
+	result, err := stmt.ExecContext(ctx, attachmentsJSON, uuid)
+	if err != nil {
+		return "", utils.PostgresErrorTransform(err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return "", utils.ErrRecordNotFound
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", utils.PostgresErrorTransform(err)
+	}
+
+	return removedFileURL, nil
+}

--- a/inbound/seawaybilldetails/service.go
+++ b/inbound/seawaybilldetails/service.go
@@ -1,0 +1,301 @@
+package seawaybilldetails
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"hpc-express-service/config"
+	"hpc-express-service/gcs"
+	"hpc-express-service/utils"
+)
+
+type Service interface {
+	CreateSeaWaybillDetails(ctx context.Context, data *UpsertSeaWaybillDetailsRequest) (*SeaWaybillDetails, error)
+	GetSeaWaybillDetails(ctx context.Context, uuid string) (*SeaWaybillDetails, error)
+	UpdateSeaWaybillDetails(ctx context.Context, uuid string, data *UpsertSeaWaybillDetailsRequest) (*SeaWaybillDetails, error)
+	DeleteSeaWaybillAttachment(ctx context.Context, uuid, fileName string) error
+}
+
+type service struct {
+	repo           Repository
+	contextTimeout time.Duration
+	gcsClient      *gcs.Client
+	conf           *config.Config
+}
+
+func NewService(repo Repository, timeout time.Duration, gcsClient *gcs.Client, conf *config.Config) Service {
+	return &service{
+		repo:           repo,
+		contextTimeout: timeout,
+		gcsClient:      gcsClient,
+		conf:           conf,
+	}
+}
+
+func (s *service) CreateSeaWaybillDetails(ctx context.Context, data *UpsertSeaWaybillDetailsRequest) (*SeaWaybillDetails, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if data == nil {
+		return nil, errors.New("request data cannot be nil")
+	}
+
+	payload, err := s.preparePayload(data, uuid.New().String())
+	if err != nil {
+		return nil, err
+	}
+
+	attachments, err := s.storeAttachments(ctx, payload.UUID, data.Attachments)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := s.repo.CreateSeaWaybillDetails(ctx, payload, attachments)
+	if err != nil {
+		s.cleanupStoredAttachments(attachments)
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *service) GetSeaWaybillDetails(ctx context.Context, uuid string) (*SeaWaybillDetails, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(uuid) == "" {
+		return nil, errors.New("uuid is required")
+	}
+
+	return s.repo.GetSeaWaybillDetails(ctx, uuid)
+}
+
+func (s *service) UpdateSeaWaybillDetails(ctx context.Context, uuid string, data *UpsertSeaWaybillDetailsRequest) (*SeaWaybillDetails, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(uuid) == "" {
+		return nil, errors.New("uuid is required")
+	}
+	if data == nil {
+		return nil, errors.New("request data cannot be nil")
+	}
+
+	payload, err := s.preparePayload(data, uuid)
+	if err != nil {
+		return nil, err
+	}
+
+	attachments, err := s.storeAttachments(ctx, uuid, data.Attachments)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := s.repo.UpdateSeaWaybillDetails(ctx, uuid, payload, attachments)
+	if err != nil {
+		s.cleanupStoredAttachments(attachments)
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *service) DeleteSeaWaybillAttachment(ctx context.Context, uuid, fileName string) error {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(uuid) == "" {
+		return errors.New("uuid is required")
+	}
+	if strings.TrimSpace(fileName) == "" {
+		return errors.New("fileName is required")
+	}
+
+	fileURL, err := s.repo.DeleteSeaWaybillAttachment(ctx, uuid, fileName)
+	if err != nil {
+		return err
+	}
+
+	if fileURL == "" {
+		return nil
+	}
+
+	if s.gcsClient != nil && strings.HasPrefix(fileURL, fmt.Sprintf("https://storage.googleapis.com/%s/", s.conf.GCSBucketName)) {
+		objectName := strings.TrimPrefix(fileURL, fmt.Sprintf("https://storage.googleapis.com/%s/", s.conf.GCSBucketName))
+		if err := s.gcsClient.DeleteImage(objectName); err != nil {
+			fmt.Printf("warning: failed to delete attachment file '%s': %v\n", objectName, err)
+		}
+		return nil
+	}
+
+	if err := os.Remove(fileURL); err != nil && !os.IsNotExist(err) {
+		fmt.Printf("warning: failed to delete attachment file '%s': %v\n", fileURL, err)
+	}
+
+	return nil
+}
+
+func (s *service) preparePayload(data *UpsertSeaWaybillDetailsRequest, uuid string) (*seaWaybillDetailsRecord, error) {
+	grossWeight, err := s.parseDecimalString(data.GrossWeight, "grossWeight")
+	if err != nil {
+		return nil, err
+	}
+
+	volumeWeight, err := s.parseDecimalString(data.VolumeWeight, "volumeWeight")
+	if err != nil {
+		return nil, err
+	}
+
+	dutyTax, err := s.parseDecimalString(data.DutyTax, "dutyTax")
+	if err != nil {
+		return nil, err
+	}
+
+	return &seaWaybillDetailsRecord{
+		UUID:         uuid,
+		GrossWeight:  grossWeight,
+		VolumeWeight: volumeWeight,
+		DutyTax:      dutyTax,
+	}, nil
+}
+
+func (s *service) parseDecimalString(value string, field string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("%s is required", field)
+	}
+
+	parsed, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return "", fmt.Errorf("%s must be a valid number", field)
+	}
+	if parsed < 0 {
+		return "", fmt.Errorf("%s must be greater than or equal to zero", field)
+	}
+
+	return fmt.Sprintf("%.2f", parsed), nil
+}
+
+func (s *service) storeAttachments(ctx context.Context, recordUUID string, files []*multipart.FileHeader) ([]AttachmentInfo, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	allowedContentTypes := map[string]bool{
+		"application/pdf":    true,
+		"image/jpeg":         true,
+		"image/png":          true,
+		"application/msword": true,
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document": true,
+	}
+
+	var attachments []AttachmentInfo
+
+	if s.gcsClient == nil {
+		basePath := filepath.Join("assets", "sea-waybill-details", recordUUID)
+		fileInfos, err := utils.UploadDocumentsToLocal(basePath, files)
+		if err != nil {
+			return nil, err
+		}
+		for _, info := range fileInfos {
+			fileURL, _ := info["filePath"].(string)
+			fileURL = filepath.ToSlash(fileURL)
+			attachments = append(attachments, AttachmentInfo{
+				FileName: info["fileName"].(string),
+				FileURL:  fileURL,
+				FileSize: info["fileSize"].(int64),
+			})
+		}
+		return attachments, nil
+	}
+
+	for _, fileHeader := range files {
+		file, err := fileHeader.Open()
+		if err != nil {
+			return nil, fmt.Errorf("failed to open attachment %s: %v", fileHeader.Filename, err)
+		}
+
+		contentType := fileHeader.Header.Get("Content-Type")
+		if contentType == "" {
+			buff := make([]byte, 512)
+			n, _ := file.Read(buff)
+			contentType = http.DetectContentType(buff[:n])
+			if seeker, ok := file.(interface {
+				Seek(int64, int) (int64, error)
+			}); ok {
+				seeker.Seek(0, 0)
+			}
+		}
+
+		ext := strings.ToLower(filepath.Ext(fileHeader.Filename))
+		switch ext {
+		case ".doc":
+			contentType = "application/msword"
+		case ".docx":
+			contentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+		case ".jpg":
+			if contentType == "" {
+				contentType = "image/jpeg"
+			}
+		}
+
+		if !allowedContentTypes[contentType] {
+			file.Close()
+			return nil, fmt.Errorf("file type not allowed: %s", contentType)
+		}
+
+		newFileName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), fileHeader.Filename)
+		fullPath := path.Join("sea-waybill-details", recordUUID, newFileName)
+
+		if _, _, err := s.gcsClient.UploadToGCS(ctx, file, fullPath, true, contentType); err != nil {
+			file.Close()
+			return nil, fmt.Errorf("failed to upload attachments: %v", err)
+		}
+		file.Close()
+
+		fileURL := fmt.Sprintf("https://storage.googleapis.com/%s/%s", s.conf.GCSBucketName, fullPath)
+		attachments = append(attachments, AttachmentInfo{
+			FileName: newFileName,
+			FileURL:  fileURL,
+			FileSize: fileHeader.Size,
+		})
+	}
+
+	return attachments, nil
+}
+
+func (s *service) cleanupStoredAttachments(attachments []AttachmentInfo) {
+	if len(attachments) == 0 {
+		return
+	}
+
+	if s.gcsClient != nil {
+		for _, attachment := range attachments {
+			prefix := fmt.Sprintf("https://storage.googleapis.com/%s/", s.conf.GCSBucketName)
+			if strings.HasPrefix(attachment.FileURL, prefix) {
+				objectName := strings.TrimPrefix(attachment.FileURL, prefix)
+				if err := s.gcsClient.DeleteImage(objectName); err != nil {
+					fmt.Printf("warning: failed to cleanup attachment '%s': %v\n", objectName, err)
+				}
+			}
+		}
+		return
+	}
+
+	for _, attachment := range attachments {
+		if err := os.Remove(attachment.FileURL); err != nil && !os.IsNotExist(err) {
+			fmt.Printf("warning: failed to cleanup attachment '%s': %v\n", attachment.FileURL, err)
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -151,6 +151,9 @@ func New(
 			}
 			r.Mount("/mawbinfo", mawbInfoSvc.router())
 
+			seaWaybillDetailsSvc := seaWaybillDetailsHandler{s.svcFactory.SeaWaybillDetailsSvc}
+			r.Mount("/shipment-details", seaWaybillDetailsSvc.router())
+
 			compareSvc := excelHandler{s.svcFactory.CompareSvc}
 			r.Mount("/compare", compareSvc.router())
 

--- a/server/shipment_details.go
+++ b/server/shipment_details.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/go-playground/validator"
+
+	"hpc-express-service/inbound/seawaybilldetails"
+)
+
+type seaWaybillDetailsHandler struct {
+	s seawaybilldetails.Service
+}
+
+func (h *seaWaybillDetailsHandler) router() chi.Router {
+	r := chi.NewRouter()
+	r.Post("/", h.createSeaWaybillDetails)
+	r.Route("/{uuid}", func(r chi.Router) {
+		r.Get("/", h.getSeaWaybillDetails)
+		r.Put("/", h.updateSeaWaybillDetails)
+		r.Delete("/attachments", h.deleteSeaWaybillAttachment)
+	})
+	return r
+}
+
+func (h *seaWaybillDetailsHandler) createSeaWaybillDetails(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("failed to parse multipart form: %v", err)))
+		return
+	}
+
+	data := &seawaybilldetails.UpsertSeaWaybillDetailsRequest{
+		GrossWeight:  r.FormValue("grossWeight"),
+		VolumeWeight: r.FormValue("volumeWeight"),
+		DutyTax:      r.FormValue("dutyTax"),
+	}
+	if r.MultipartForm != nil && r.MultipartForm.File != nil {
+		if files, exists := r.MultipartForm.File["attachments"]; exists {
+			data.Attachments = files
+		}
+	}
+
+	validate := validator.New()
+	if err := validate.Struct(data); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	result, err := h.s.CreateSeaWaybillDetails(ctx, data)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(result, "success"))
+}
+
+func (h *seaWaybillDetailsHandler) getSeaWaybillDetails(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	uuid := chi.URLParam(r, "uuid")
+	if uuid == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("uuid parameter is required")))
+		return
+	}
+
+	result, err := h.s.GetSeaWaybillDetails(ctx, uuid)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(result, "success"))
+}
+
+func (h *seaWaybillDetailsHandler) updateSeaWaybillDetails(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	uuid := chi.URLParam(r, "uuid")
+	if uuid == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("uuid parameter is required")))
+		return
+	}
+
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("failed to parse multipart form: %v", err)))
+		return
+	}
+
+	data := &seawaybilldetails.UpsertSeaWaybillDetailsRequest{
+		GrossWeight:  r.FormValue("grossWeight"),
+		VolumeWeight: r.FormValue("volumeWeight"),
+		DutyTax:      r.FormValue("dutyTax"),
+	}
+	if r.MultipartForm != nil && r.MultipartForm.File != nil {
+		if files, exists := r.MultipartForm.File["attachments"]; exists {
+			data.Attachments = files
+		}
+	}
+
+	validate := validator.New()
+	if err := validate.Struct(data); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	result, err := h.s.UpdateSeaWaybillDetails(ctx, uuid, data)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(result, "success"))
+}
+
+func (h *seaWaybillDetailsHandler) deleteSeaWaybillAttachment(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	uuid := chi.URLParam(r, "uuid")
+	if uuid == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("uuid parameter is required")))
+		return
+	}
+
+	data := &seawaybilldetails.DeleteAttachmentRequest{}
+	if err := render.Bind(r, data); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	validate := validator.New()
+	if err := validate.Struct(data); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	if err := h.s.DeleteSeaWaybillAttachment(ctx, uuid, data.FileName); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(nil, "success"))
+}

--- a/utils/upload.go
+++ b/utils/upload.go
@@ -127,6 +127,8 @@ func UploadDocumentsToLocal(path string, files []*multipart.FileHeader) ([]map[s
 		"application/pdf":          true,
 		"application/vnd.ms-excel": true,
 		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": true,
+		"application/msword": true,
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document": true,
 		"image/jpeg": true,
 		"image/png":  true,
 		"image/jpg":  true,
@@ -163,6 +165,10 @@ func UploadDocumentsToLocal(path string, files []*multipart.FileHeader) ([]map[s
 			} else {
 				filetype = "application/vnd.ms-excel"
 			}
+		} else if ext == ".docx" {
+			filetype = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+		} else if ext == ".doc" {
+			filetype = "application/msword"
 		}
 
 		// Validate file type


### PR DESCRIPTION
## Summary
- move the sea waybill details module from the outbound tree into inbound/seawaybilldetails
- update the service and repository factories to import the module from its new inbound location
- adjust the shipment details HTTP handler to reference the relocated package

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68cd123e888c832e8b74f0c80e6382f0