### PR TITLE
Add inbound sea waybill detail endpoints

### DIFF
--- a/factory/repository.go
+++ b/factory/repository.go
@@ -7,6 +7,7 @@ import (
 	"hpc-express-service/dashboard"
 	"hpc-express-service/dropdown"
 	inbound "hpc-express-service/inbound/express"
+	seaWaybill "hpc-express-service/inbound/seawaybill"
 	"hpc-express-service/mawb"
 	cargoManifest "hpc-express-service/outbound/cargomanifest"
 	draftMawb "hpc-express-service/outbound/draftmawb"
@@ -28,6 +29,7 @@ type RepositoryFactory struct {
 	CompareRepo                   compare.ExcelRepositoryInterface
 	DropdownRepo                  dropdown.Repository
 	InboundExpressRepositoryRepo  inbound.InboundExpressRepository
+	SeaWaybillDetailRepo          seaWaybill.Repository
 	Ship2cuRepo                   ship2cu.Repository
 	UploadlogRepo                 uploadlog.Repository
 	OutboundExpressRepositoryRepo outboundExpress.OutboundExpressRepository
@@ -52,6 +54,7 @@ func NewRepositoryFactory() *RepositoryFactory {
 		CommonRepo:                    common.NewRepository(timeoutContext),
 		DropdownRepo:                  dropdown.NewRepository(),
 		InboundExpressRepositoryRepo:  inbound.NewInboundExpressRepository(timeoutContext),
+		SeaWaybillDetailRepo:          seaWaybill.NewRepository(timeoutContext),
 		Ship2cuRepo:                   ship2cu.NewRepository(timeoutContext),
 		UploadlogRepo:                 uploadlog.NewRepository(timeoutContext),
 		OutboundExpressRepositoryRepo: outboundExpress.NewOutboundExpressRepository(timeoutContext),

--- a/factory/service.go
+++ b/factory/service.go
@@ -11,6 +11,7 @@ import (
 	"hpc-express-service/dropdown"
 	"hpc-express-service/gcs"
 	inbound "hpc-express-service/inbound/express"
+	seaWaybill "hpc-express-service/inbound/seawaybill"
 	"hpc-express-service/mawb"
 	cargoManifest "hpc-express-service/outbound/cargomanifest"
 	draftMawb "hpc-express-service/outbound/draftmawb"
@@ -31,6 +32,7 @@ type ServiceFactory struct {
 	CompareSvc                compare.ExcelServiceInterface
 	DropdownSvc               dropdown.Service
 	InboundExpressServiceSvc  inbound.InboundExpressService
+	SeaWaybillDetailSvc       seaWaybill.Service
 	Ship2cuSvc                ship2cu.Service
 	UploadlogSvc              uploadlog.Service
 	OutboundExpressServiceSvc outboundExpress.OutboundExpressService
@@ -148,6 +150,13 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 		repo.Ship2cuRepo,
 	)
 
+	seaWaybillDetailSvc := seaWaybill.NewService(
+		repo.SeaWaybillDetailRepo,
+		timeoutContext,
+		gcsClient,
+		conf,
+	)
+
 	// Outbound Express
 	outboundExpressServiceSvc := outboundExpress.NewOutboundExpressService(
 		repo.OutboundExpressRepositoryRepo,
@@ -175,6 +184,7 @@ func NewServiceFactory(repo *RepositoryFactory, gcsClient *gcs.Client, conf *con
 		CommonSvc:                 commonSvc,
 		DropdownSvc:               dropdownSvc,
 		InboundExpressServiceSvc:  inboundExpressServiceSvc,
+		SeaWaybillDetailSvc:       seaWaybillDetailSvc,
 		Ship2cuSvc:                ship2cuSvc,
 		UploadlogSvc:              uploadlogSvc,
 		OutboundExpressServiceSvc: outboundExpressServiceSvc,

--- a/inbound/seawaybill/models.go
+++ b/inbound/seawaybill/models.go
@@ -1,0 +1,69 @@
+package seawaybill
+
+import (
+	"mime/multipart"
+	"net/http"
+)
+
+// AttachmentInfo represents stored attachment metadata.
+type AttachmentInfo struct {
+	FileName string `json:"fileName"`
+	FileURL  string `json:"fileUrl"`
+	FileSize int64  `json:"fileSize"`
+}
+
+// SeaWaybillDetailResponse represents the response payload for sea waybill details.
+type SeaWaybillDetailResponse struct {
+	UUID         string           `json:"uuid"`
+	GrossWeight  float64          `json:"grossWeight"`
+	VolumeWeight float64          `json:"volumeWeight"`
+	DutyTax      float64          `json:"dutyTax"`
+	Attachments  []AttachmentInfo `json:"attachments"`
+	CreatedAt    string           `json:"createdAt"`
+	UpdatedAt    string           `json:"updatedAt"`
+}
+
+// CreateSeaWaybillDetailRequest holds form values for creating a record.
+type CreateSeaWaybillDetailRequest struct {
+	GrossWeight  string                  `form:"grossWeight" validate:"required"`
+	VolumeWeight string                  `form:"volumeWeight" validate:"required"`
+	DutyTax      string                  `form:"dutyTax" validate:"required"`
+	Attachments  []*multipart.FileHeader `form:"attachments"`
+}
+
+// Bind implements render.Binder interface.
+func (r *CreateSeaWaybillDetailRequest) Bind(req *http.Request) error {
+	return nil
+}
+
+// UpdateSeaWaybillDetailRequest holds form values for updating a record.
+type UpdateSeaWaybillDetailRequest struct {
+	GrossWeight  string                  `form:"grossWeight" validate:"required"`
+	VolumeWeight string                  `form:"volumeWeight" validate:"required"`
+	DutyTax      string                  `form:"dutyTax" validate:"required"`
+	Attachments  []*multipart.FileHeader `form:"attachments"`
+}
+
+// Bind implements render.Binder interface.
+func (r *UpdateSeaWaybillDetailRequest) Bind(req *http.Request) error {
+	return nil
+}
+
+// DeleteAttachmentRequest represents a request to remove an attachment.
+type DeleteAttachmentRequest struct {
+	FileName string `json:"fileName" validate:"required"`
+}
+
+// Bind implements render.Binder interface.
+func (r *DeleteAttachmentRequest) Bind(req *http.Request) error {
+	return nil
+}
+
+// seaWaybillDetailData represents sanitized data used by the repository layer.
+type seaWaybillDetailData struct {
+	UUID         string
+	GrossWeight  float64
+	VolumeWeight float64
+	DutyTax      float64
+	Attachments  []AttachmentInfo
+}

--- a/inbound/seawaybill/repository.go
+++ b/inbound/seawaybill/repository.go
@@ -1,0 +1,327 @@
+package seawaybill
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-pg/pg/v9"
+
+	"hpc-express-service/utils"
+)
+
+// Repository defines database operations for sea waybill details.
+type Repository interface {
+	CreateSeaWaybillDetail(ctx context.Context, data *seaWaybillDetailData) (*SeaWaybillDetailResponse, error)
+	GetSeaWaybillDetail(ctx context.Context, uuid string) (*SeaWaybillDetailResponse, error)
+	UpdateSeaWaybillDetail(ctx context.Context, data *seaWaybillDetailData) (*SeaWaybillDetailResponse, error)
+	DeleteAttachment(ctx context.Context, uuid, fileName string) (string, error)
+}
+
+type repository struct {
+	contextTimeout time.Duration
+}
+
+// NewRepository creates a new repository instance.
+func NewRepository(timeout time.Duration) Repository {
+	return &repository{contextTimeout: timeout}
+}
+
+func (r repository) CreateSeaWaybillDetail(ctx context.Context, data *seaWaybillDetailData) (*SeaWaybillDetailResponse, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	attachmentsJSON := "[]"
+	if len(data.Attachments) > 0 {
+		b, err := json.Marshal(data.Attachments)
+		if err != nil {
+			return nil, err
+		}
+		attachmentsJSON = string(b)
+	}
+
+	sqlStr := `
+        INSERT INTO public.tbl_sea_waybill_details
+            (uuid, gross_weight, volume_weight, duty_tax, attachments)
+        VALUES
+            (?, ?, ?, ?, ?::jsonb)
+        RETURNING
+            uuid,
+            gross_weight,
+            volume_weight,
+            duty_tax,
+            COALESCE(attachments::text, '[]') as attachments,
+            to_char(created_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as created_at,
+            to_char(updated_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at
+    `
+
+	sqlStr = utils.ReplaceSQL(sqlStr, "?")
+	stmt, err := db.Prepare(sqlStr)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+	defer stmt.Close()
+
+	var (
+		result          SeaWaybillDetailResponse
+		attachmentsText string
+	)
+
+	_, err = stmt.QueryOneContext(ctx, pg.Scan(
+		&result.UUID,
+		&result.GrossWeight,
+		&result.VolumeWeight,
+		&result.DutyTax,
+		&attachmentsText,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	),
+		data.UUID,
+		data.GrossWeight,
+		data.VolumeWeight,
+		data.DutyTax,
+		attachmentsJSON,
+	)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	if attachmentsText != "" && attachmentsText != "[]" {
+		if err := json.Unmarshal([]byte(attachmentsText), &result.Attachments); err != nil {
+			return nil, fmt.Errorf("failed to parse attachments: %w", err)
+		}
+	}
+
+	return &result, nil
+}
+
+func (r repository) GetSeaWaybillDetail(ctx context.Context, uuid string) (*SeaWaybillDetailResponse, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sqlStr := `
+        SELECT
+            uuid,
+            gross_weight,
+            volume_weight,
+            duty_tax,
+            COALESCE(attachments::text, '[]') as attachments,
+            to_char(created_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as created_at,
+            to_char(updated_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at
+        FROM public.tbl_sea_waybill_details
+        WHERE uuid = ?
+    `
+
+	sqlStr = utils.ReplaceSQL(sqlStr, "?")
+	stmt, err := db.Prepare(sqlStr)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+	defer stmt.Close()
+
+	var (
+		result          SeaWaybillDetailResponse
+		attachmentsText string
+	)
+
+	_, err = stmt.QueryOneContext(ctx, pg.Scan(
+		&result.UUID,
+		&result.GrossWeight,
+		&result.VolumeWeight,
+		&result.DutyTax,
+		&attachmentsText,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	), uuid)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	if attachmentsText != "" && attachmentsText != "[]" {
+		if err := json.Unmarshal([]byte(attachmentsText), &result.Attachments); err != nil {
+			return nil, fmt.Errorf("failed to parse attachments: %w", err)
+		}
+	}
+
+	return &result, nil
+}
+
+func (r repository) UpdateSeaWaybillDetail(ctx context.Context, data *seaWaybillDetailData) (*SeaWaybillDetailResponse, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var existingAttachmentsText string
+	_, err := db.QueryOneContext(ctx, pg.Scan(&existingAttachmentsText), `
+        SELECT COALESCE(attachments::text, '[]')
+        FROM public.tbl_sea_waybill_details
+        WHERE uuid = ?
+    `, data.UUID)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	var combinedAttachments []AttachmentInfo
+	if existingAttachmentsText != "" && existingAttachmentsText != "[]" {
+		if err := json.Unmarshal([]byte(existingAttachmentsText), &combinedAttachments); err != nil {
+			return nil, fmt.Errorf("failed to parse existing attachments: %w", err)
+		}
+	}
+
+	if len(data.Attachments) > 0 {
+		combinedAttachments = append(combinedAttachments, data.Attachments...)
+	}
+
+	attachmentsJSON := "[]"
+	if len(combinedAttachments) > 0 {
+		b, err := json.Marshal(combinedAttachments)
+		if err != nil {
+			return nil, err
+		}
+		attachmentsJSON = string(b)
+	}
+
+	sqlStr := `
+        UPDATE public.tbl_sea_waybill_details
+        SET
+            gross_weight = ?,
+            volume_weight = ?,
+            duty_tax = ?,
+            attachments = ?::jsonb,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE uuid = ?
+        RETURNING
+            uuid,
+            gross_weight,
+            volume_weight,
+            duty_tax,
+            COALESCE(attachments::text, '[]') as attachments,
+            to_char(created_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as created_at,
+            to_char(updated_at at time zone 'utc' at time zone 'Asia/Bangkok', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at
+    `
+
+	sqlStr = utils.ReplaceSQL(sqlStr, "?")
+	stmt, err := db.Prepare(sqlStr)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+	defer stmt.Close()
+
+	var (
+		result          SeaWaybillDetailResponse
+		attachmentsText string
+	)
+
+	_, err = stmt.QueryOneContext(ctx, pg.Scan(
+		&result.UUID,
+		&result.GrossWeight,
+		&result.VolumeWeight,
+		&result.DutyTax,
+		&attachmentsText,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	),
+		data.GrossWeight,
+		data.VolumeWeight,
+		data.DutyTax,
+		attachmentsJSON,
+		data.UUID,
+	)
+	if err != nil {
+		return nil, utils.PostgresErrorTransform(err)
+	}
+
+	if attachmentsText != "" && attachmentsText != "[]" {
+		if err := json.Unmarshal([]byte(attachmentsText), &result.Attachments); err != nil {
+			return nil, fmt.Errorf("failed to parse attachments: %w", err)
+		}
+	}
+
+	return &result, nil
+}
+
+func (r repository) DeleteAttachment(ctx context.Context, uuid, fileName string) (string, error) {
+	db := ctx.Value("postgreSQLConn").(*pg.DB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return "", err
+	}
+	defer tx.Close()
+
+	var attachmentsText string
+	_, err = tx.QueryOneContext(ctx, pg.Scan(&attachmentsText), `
+        SELECT COALESCE(attachments::text, '[]')
+        FROM public.tbl_sea_waybill_details
+        WHERE uuid = ?
+        FOR UPDATE
+    `, uuid)
+	if err != nil {
+		tx.Rollback()
+		return "", utils.PostgresErrorTransform(err)
+	}
+
+	var attachments []AttachmentInfo
+	if attachmentsText != "" && attachmentsText != "[]" {
+		if err := json.Unmarshal([]byte(attachmentsText), &attachments); err != nil {
+			tx.Rollback()
+			return "", fmt.Errorf("failed to parse attachments: %w", err)
+		}
+	}
+
+	updatedAttachments := make([]AttachmentInfo, 0, len(attachments))
+	removedURL := ""
+	for _, attachment := range attachments {
+		if attachment.FileName == fileName {
+			removedURL = attachment.FileURL
+			continue
+		}
+		updatedAttachments = append(updatedAttachments, attachment)
+	}
+
+	if removedURL == "" {
+		tx.Rollback()
+		return "", utils.ErrRecordNotFound
+	}
+
+	attachmentsJSON := "[]"
+	if len(updatedAttachments) > 0 {
+		b, err := json.Marshal(updatedAttachments)
+		if err != nil {
+			tx.Rollback()
+			return "", err
+		}
+		attachmentsJSON = string(b)
+	}
+
+	sqlStr := `
+        UPDATE public.tbl_sea_waybill_details
+        SET attachments = ?::jsonb, updated_at = CURRENT_TIMESTAMP
+        WHERE uuid = ?
+    `
+
+	sqlStr = utils.ReplaceSQL(sqlStr, "?")
+	stmt, err := tx.Prepare(sqlStr)
+	if err != nil {
+		tx.Rollback()
+		return "", utils.PostgresErrorTransform(err)
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(attachmentsJSON, uuid)
+	if err != nil {
+		tx.Rollback()
+		return "", utils.PostgresErrorTransform(err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", utils.PostgresErrorTransform(err)
+	}
+
+	return removedURL, nil
+}

--- a/inbound/seawaybill/service.go
+++ b/inbound/seawaybill/service.go
@@ -1,0 +1,339 @@
+package seawaybill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"hpc-express-service/config"
+	"hpc-express-service/gcs"
+)
+
+// Service exposes business logic for sea waybill details.
+type Service interface {
+	CreateSeaWaybillDetail(ctx context.Context, data *CreateSeaWaybillDetailRequest) (*SeaWaybillDetailResponse, error)
+	GetSeaWaybillDetail(ctx context.Context, uuid string) (*SeaWaybillDetailResponse, error)
+	UpdateSeaWaybillDetail(ctx context.Context, uuid string, data *UpdateSeaWaybillDetailRequest) (*SeaWaybillDetailResponse, error)
+	DeleteAttachment(ctx context.Context, uuid, fileName string) error
+}
+
+type service struct {
+	selfRepo       Repository
+	contextTimeout time.Duration
+	gcsClient      *gcs.Client
+	conf           *config.Config
+}
+
+// NewService creates a new Service instance.
+func NewService(repo Repository, timeout time.Duration, gcsClient *gcs.Client, conf *config.Config) Service {
+	return &service{
+		selfRepo:       repo,
+		contextTimeout: timeout,
+		gcsClient:      gcsClient,
+		conf:           conf,
+	}
+}
+
+func (s *service) CreateSeaWaybillDetail(ctx context.Context, data *CreateSeaWaybillDetailRequest) (*SeaWaybillDetailResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if data == nil {
+		return nil, errors.New("request data cannot be nil")
+	}
+
+	grossWeight, err := parseDecimal(data.GrossWeight)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeWeight, err := parseDecimal(data.VolumeWeight)
+	if err != nil {
+		return nil, err
+	}
+
+	dutyTax, err := parseDecimal(data.DutyTax)
+	if err != nil {
+		return nil, err
+	}
+
+	recordUUID := uuid.New().String()
+
+	attachmentInfos, err := s.storeAttachments(ctx, recordUUID, data.Attachments)
+	if err != nil {
+		return nil, err
+	}
+
+	repoData := &seaWaybillDetailData{
+		UUID:         recordUUID,
+		GrossWeight:  grossWeight,
+		VolumeWeight: volumeWeight,
+		DutyTax:      dutyTax,
+		Attachments:  attachmentInfos,
+	}
+
+	result, err := s.selfRepo.CreateSeaWaybillDetail(ctx, repoData)
+	if err != nil {
+		s.cleanupAttachments(attachmentInfos)
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *service) GetSeaWaybillDetail(ctx context.Context, uuid string) (*SeaWaybillDetailResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(uuid) == "" {
+		return nil, errors.New("uuid is required")
+	}
+
+	return s.selfRepo.GetSeaWaybillDetail(ctx, uuid)
+}
+
+func (s *service) UpdateSeaWaybillDetail(ctx context.Context, uuid string, data *UpdateSeaWaybillDetailRequest) (*SeaWaybillDetailResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(uuid) == "" {
+		return nil, errors.New("uuid is required")
+	}
+
+	if data == nil {
+		return nil, errors.New("request data cannot be nil")
+	}
+
+	grossWeight, err := parseDecimal(data.GrossWeight)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeWeight, err := parseDecimal(data.VolumeWeight)
+	if err != nil {
+		return nil, err
+	}
+
+	dutyTax, err := parseDecimal(data.DutyTax)
+	if err != nil {
+		return nil, err
+	}
+
+	attachmentInfos, err := s.storeAttachments(ctx, uuid, data.Attachments)
+	if err != nil {
+		return nil, err
+	}
+
+	repoData := &seaWaybillDetailData{
+		UUID:         uuid,
+		GrossWeight:  grossWeight,
+		VolumeWeight: volumeWeight,
+		DutyTax:      dutyTax,
+		Attachments:  attachmentInfos,
+	}
+
+	result, err := s.selfRepo.UpdateSeaWaybillDetail(ctx, repoData)
+	if err != nil {
+		s.cleanupAttachments(attachmentInfos)
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *service) DeleteAttachment(ctx context.Context, uuid, fileName string) error {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	if strings.TrimSpace(uuid) == "" {
+		return errors.New("uuid is required")
+	}
+	if strings.TrimSpace(fileName) == "" {
+		return errors.New("fileName is required")
+	}
+
+	fileURL, err := s.selfRepo.DeleteAttachment(ctx, uuid, fileName)
+	if err != nil {
+		return err
+	}
+
+	if fileURL != "" {
+		s.removeStoredFile(fileURL)
+	}
+
+	return nil
+}
+
+func parseDecimal(value string) (float64, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, errors.New("value is required")
+	}
+
+	parsed, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid numeric value: %s", value)
+	}
+
+	return parsed, nil
+}
+
+func (s *service) storeAttachments(ctx context.Context, recordUUID string, files []*multipart.FileHeader) ([]AttachmentInfo, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	const maxFileSize = 5 * 1024 * 1024 // 5MB
+	allowedContentTypes := map[string]bool{
+		"application/pdf":    true,
+		"image/jpeg":         true,
+		"image/png":          true,
+		"image/jpg":          true,
+		"application/msword": true,
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document": true,
+	}
+
+	attachments := make([]AttachmentInfo, 0, len(files))
+
+	for _, fileHeader := range files {
+		if fileHeader.Size > maxFileSize {
+			return nil, fmt.Errorf("file %s is larger than 5MB", fileHeader.Filename)
+		}
+
+		file, err := fileHeader.Open()
+		if err != nil {
+			return nil, fmt.Errorf("failed to open file %s: %w", fileHeader.Filename, err)
+		}
+
+		contentType := fileHeader.Header.Get("Content-Type")
+		if contentType == "" {
+			buffer := make([]byte, 512)
+			n, _ := file.Read(buffer)
+			contentType = http.DetectContentType(buffer[:n])
+			if seeker, ok := file.(io.Seeker); ok {
+				seeker.Seek(0, io.SeekStart)
+			} else {
+				file.Close()
+				file, err = fileHeader.Open()
+				if err != nil {
+					return nil, fmt.Errorf("failed to reopen file %s: %w", fileHeader.Filename, err)
+				}
+			}
+		}
+
+		if !allowedContentTypes[contentType] {
+			lowerExt := strings.ToLower(filepath.Ext(fileHeader.Filename))
+			if !(lowerExt == ".doc" || lowerExt == ".docx") {
+				file.Close()
+				return nil, fmt.Errorf("file type %s is not allowed", contentType)
+			}
+		}
+
+		newFileName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), sanitizeFileName(fileHeader.Filename))
+
+		var fileURL string
+		if s.gcsClient != nil {
+			if seeker, ok := file.(io.Seeker); ok {
+				seeker.Seek(0, io.SeekStart)
+			} else {
+				file.Close()
+				file, err = fileHeader.Open()
+				if err != nil {
+					return nil, fmt.Errorf("failed to reopen file %s: %w", fileHeader.Filename, err)
+				}
+			}
+
+			objectPath := path.Join("sea-waybill-details", recordUUID, newFileName)
+			if _, _, err := s.gcsClient.UploadToGCS(ctx, file, objectPath, true, contentType); err != nil {
+				file.Close()
+				return nil, fmt.Errorf("failed to upload file %s: %w", fileHeader.Filename, err)
+			}
+			fileURL = fmt.Sprintf("https://storage.googleapis.com/%s/%s", s.conf.GCSBucketName, objectPath)
+		} else {
+			basePath := filepath.Join("assets", "sea-waybill-details", recordUUID)
+			if err := os.MkdirAll(basePath, os.ModePerm); err != nil {
+				file.Close()
+				return nil, fmt.Errorf("failed to create directory: %w", err)
+			}
+
+			destinationPath := filepath.Join(basePath, newFileName)
+			destFile, err := os.Create(destinationPath)
+			if err != nil {
+				file.Close()
+				return nil, fmt.Errorf("failed to create file: %w", err)
+			}
+
+			if seeker, ok := file.(io.Seeker); ok {
+				seeker.Seek(0, io.SeekStart)
+			}
+
+			if _, err := io.Copy(destFile, file); err != nil {
+				destFile.Close()
+				file.Close()
+				return nil, fmt.Errorf("failed to save file: %w", err)
+			}
+			destFile.Close()
+			fileURL = filepath.ToSlash(destinationPath)
+		}
+
+		file.Close()
+
+		attachments = append(attachments, AttachmentInfo{
+			FileName: newFileName,
+			FileURL:  fileURL,
+			FileSize: fileHeader.Size,
+		})
+	}
+
+	return attachments, nil
+}
+
+func (s *service) cleanupAttachments(attachments []AttachmentInfo) {
+	for _, attachment := range attachments {
+		s.removeStoredFile(attachment.FileURL)
+	}
+}
+
+func (s *service) removeStoredFile(fileURL string) {
+	if fileURL == "" {
+		return
+	}
+
+	if s.gcsClient != nil && strings.HasPrefix(fileURL, "https://storage.googleapis.com/") {
+		prefix := fmt.Sprintf("https://storage.googleapis.com/%s/", s.conf.GCSBucketName)
+		if strings.HasPrefix(fileURL, prefix) {
+			objectName := strings.TrimPrefix(fileURL, prefix)
+			if err := s.gcsClient.DeleteImage(objectName); err != nil {
+				fmt.Printf("warning: failed to delete GCS object %s: %v\n", objectName, err)
+			}
+			return
+		}
+	}
+
+	if err := os.Remove(fileURL); err != nil && !os.IsNotExist(err) {
+		fmt.Printf("warning: failed to delete file %s: %v\n", fileURL, err)
+	}
+}
+
+func sanitizeFileName(name string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\\', '/', ':', '*', '?', '"', '<', '>', '|':
+			return '-'
+		default:
+			return r
+		}
+	}, name)
+	return cleaned
+}

--- a/server/inbound_seawaybill.go
+++ b/server/inbound_seawaybill.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/go-playground/validator"
+
+	seawaybill "hpc-express-service/inbound/seawaybill"
+)
+
+type seaWaybillHandler struct {
+	s seawaybill.Service
+}
+
+func (h *seaWaybillHandler) router() chi.Router {
+	r := chi.NewRouter()
+
+	r.Post("/", h.createSeaWaybillDetail)
+	r.Get("/{uuid}", h.getSeaWaybillDetail)
+	r.Put("/{uuid}", h.updateSeaWaybillDetail)
+	r.Delete("/{uuid}/attachments", h.deleteAttachment)
+
+	return r
+}
+
+func (h *seaWaybillHandler) createSeaWaybillDetail(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("failed to parse multipart form: %w", err)))
+		return
+	}
+	if r.MultipartForm != nil {
+		defer r.MultipartForm.RemoveAll()
+	}
+
+	data := &seawaybill.CreateSeaWaybillDetailRequest{
+		GrossWeight:  r.FormValue("grossWeight"),
+		VolumeWeight: r.FormValue("volumeWeight"),
+		DutyTax:      r.FormValue("dutyTax"),
+	}
+
+	if r.MultipartForm != nil && r.MultipartForm.File != nil {
+		if files, ok := r.MultipartForm.File["attachments"]; ok {
+			data.Attachments = files
+		}
+	}
+
+	validate := validator.New()
+	if err := validate.Struct(data); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	result, err := h.s.CreateSeaWaybillDetail(ctx, data)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(result, "success"))
+}
+
+func (h *seaWaybillHandler) getSeaWaybillDetail(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	uuid := chi.URLParam(r, "uuid")
+	if uuid == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("uuid parameter is required")))
+		return
+	}
+
+	result, err := h.s.GetSeaWaybillDetail(ctx, uuid)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(result, "success"))
+}
+
+func (h *seaWaybillHandler) updateSeaWaybillDetail(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	uuid := chi.URLParam(r, "uuid")
+	if uuid == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("uuid parameter is required")))
+		return
+	}
+
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("failed to parse multipart form: %w", err)))
+		return
+	}
+	if r.MultipartForm != nil {
+		defer r.MultipartForm.RemoveAll()
+	}
+
+	data := &seawaybill.UpdateSeaWaybillDetailRequest{
+		GrossWeight:  r.FormValue("grossWeight"),
+		VolumeWeight: r.FormValue("volumeWeight"),
+		DutyTax:      r.FormValue("dutyTax"),
+	}
+
+	if r.MultipartForm != nil && r.MultipartForm.File != nil {
+		if files, ok := r.MultipartForm.File["attachments"]; ok {
+			data.Attachments = files
+		}
+	}
+
+	validate := validator.New()
+	if err := validate.Struct(data); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	result, err := h.s.UpdateSeaWaybillDetail(ctx, uuid, data)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(result, "success"))
+}
+
+func (h *seaWaybillHandler) deleteAttachment(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	uuid := chi.URLParam(r, "uuid")
+	if uuid == "" {
+		render.Render(w, r, ErrInvalidRequest(fmt.Errorf("uuid parameter is required")))
+		return
+	}
+
+	request := &seawaybill.DeleteAttachmentRequest{}
+	if err := render.Bind(r, request); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	validate := validator.New()
+	if err := validate.Struct(request); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	if err := h.s.DeleteAttachment(ctx, uuid, request.FileName); err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(nil, "success"))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,8 @@ func New(
 			r.Route("/inbound", func(r chi.Router) {
 				inboundExpressServiceSvc := inboundExpressHandler{s.svcFactory.InboundExpressServiceSvc}
 				r.Mount("/express", inboundExpressServiceSvc.router())
+				seaWaybillServiceSvc := seaWaybillHandler{s.svcFactory.SeaWaybillDetailSvc}
+				r.Mount("/sea-waybill-details", seaWaybillServiceSvc.router())
 			})
 
 			r.Route("/outbound", func(r chi.Router) {


### PR DESCRIPTION
## Summary
- add sea waybill detail models, repository, and service with attachment handling backed by tbl_sea_waybill_details
- expose inbound HTTP endpoints for creating, retrieving, updating, and deleting sea waybill detail attachments
- register the new sea waybill detail service and handler with the factories and inbound router

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd1b8a0d50832e998be7d417d6f1c3