### PR TITLE
Add endpoint to list sea waybill details

### DIFF
--- a/inbound/seawaybill/service.go
+++ b/inbound/seawaybill/service.go
@@ -23,6 +23,7 @@ import (
 // Service exposes business logic for sea waybill details.
 type Service interface {
 	CreateSeaWaybillDetail(ctx context.Context, data *CreateSeaWaybillDetailRequest) (*SeaWaybillDetailResponse, error)
+	ListSeaWaybillDetails(ctx context.Context) ([]*SeaWaybillDetailResponse, error)
 	GetSeaWaybillDetail(ctx context.Context, uuid string) (*SeaWaybillDetailResponse, error)
 	UpdateSeaWaybillDetail(ctx context.Context, uuid string, data *UpdateSeaWaybillDetailRequest) (*SeaWaybillDetailResponse, error)
 	DeleteAttachment(ctx context.Context, uuid, fileName string) error
@@ -90,6 +91,13 @@ func (s *service) CreateSeaWaybillDetail(ctx context.Context, data *CreateSeaWay
 	}
 
 	return result, nil
+}
+
+func (s *service) ListSeaWaybillDetails(ctx context.Context) ([]*SeaWaybillDetailResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.contextTimeout)
+	defer cancel()
+
+	return s.selfRepo.ListSeaWaybillDetails(ctx)
 }
 
 func (s *service) GetSeaWaybillDetail(ctx context.Context, uuid string) (*SeaWaybillDetailResponse, error) {

--- a/server/inbound_seawaybill.go
+++ b/server/inbound_seawaybill.go
@@ -19,12 +19,28 @@ type seaWaybillHandler struct {
 func (h *seaWaybillHandler) router() chi.Router {
 	r := chi.NewRouter()
 
+	r.Get("/", h.listSeaWaybillDetails)
 	r.Post("/", h.createSeaWaybillDetail)
 	r.Get("/{uuid}", h.getSeaWaybillDetail)
 	r.Put("/{uuid}", h.updateSeaWaybillDetail)
 	r.Delete("/{uuid}/attachments", h.deleteAttachment)
 
 	return r
+}
+
+func (h *seaWaybillHandler) listSeaWaybillDetails(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	result, err := h.s.ListSeaWaybillDetails(ctx)
+	if err != nil {
+		render.Render(w, r, ErrInvalidRequest(err))
+		return
+	}
+
+	render.Respond(w, r, SuccessResponse(result, "success"))
 }
 
 func (h *seaWaybillHandler) createSeaWaybillDetail(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- extend the sea waybill repository and service to fetch all stored records
- add a GET /inbound/sea-waybill-details endpoint that returns the complete list

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd241b9ad0832ebd89d857709d717d